### PR TITLE
Adapt to latest changes in downloads.mariadb.org

### DIFF
--- a/scripts/autobump-mariadb.sh
+++ b/scripts/autobump-mariadb.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export VERSIONS_URL='https://downloads.mariadb.org/mariadb/+releases/'
 
 HTML="$(curl -s -L "${VERSIONS_URL}")"
-VALUES="$(echo "${HTML}" | xmllint --html --xpath "//table[@id='download']/tbody/tr[td[3]='Stable']/td[1]/a/@href" - 2>/dev/null)"
+VALUES="$(echo "${HTML}" | xmllint --html --xpath "//table/tbody/tr[td[3]='Stable']/td[1]/a/@href" - 2>/dev/null)"
 ALL_VERSIONS="$(echo "${VALUES}" | grep -Eo '[0-9]+(\.[0-9]+){1,2}')"
 
 export BLOBS_PREFIX="mariadb"


### PR DESCRIPTION
MariaDB downloads webpage has changed slightly its internal structure.
With the current logic, the list of available versions remains always empty.

These changes fix the problem and all stable version numbers get listed.