### PR TITLE
Fix pcre2 BOSH compilation

### DIFF
--- a/packages/libpcre2/packaging
+++ b/packages/libpcre2/packaging
@@ -18,9 +18,10 @@ set -e
 
 LIBPCRE2_VERSION=10.39
 
-tar xzf libpcre2/pcre2-${LIBPCRE2_VERSION}.tar.gz
+mkdir -p pcre2-${LIBPCRE2_VERSION} && tar xzf libpcre2/pcre2-${LIBPCRE2_VERSION}.tar.gz -C pcre2-${LIBPCRE2_VERSION}  --strip-components=1
 
 cd pcre2-${LIBPCRE2_VERSION}
-CFLAGS="-Dregcomp=PCRE2regcomp" ./configure --prefix=${BOSH_INSTALL_TARGET}
+./autogen.sh
+CFLAGS="-Dregcomp=PCRE2regcomp" ./configure --prefix="${BOSH_INSTALL_TARGET}"
 make
 make install


### PR DESCRIPTION
As we changed the URL from where the artefact is downloaded, the new
artefact does not have a `configure` script. Hence we have to call
`autogen.sh` which used `autoconf` (present in stemcells) to create a
new `configure` script.