### PR TITLE
Revert "Fix pcre2 BOSH compilation"

### DIFF
--- a/packages/libpcre2/packaging
+++ b/packages/libpcre2/packaging
@@ -18,10 +18,9 @@ set -e
 
 LIBPCRE2_VERSION=10.39
 
-mkdir -p pcre2-${LIBPCRE2_VERSION} && tar xzf libpcre2/pcre2-${LIBPCRE2_VERSION}.tar.gz -C pcre2-${LIBPCRE2_VERSION}  --strip-components=1
+tar xzf libpcre2/pcre2-${LIBPCRE2_VERSION}.tar.gz
 
 cd pcre2-${LIBPCRE2_VERSION}
-./autogen.sh
-CFLAGS="-Dregcomp=PCRE2regcomp" ./configure --prefix="${BOSH_INSTALL_TARGET}"
+CFLAGS="-Dregcomp=PCRE2regcomp" ./configure --prefix=${BOSH_INSTALL_TARGET}
 make
 make install

--- a/scripts/autobump-libpcre2.sh
+++ b/scripts/autobump-libpcre2.sh
@@ -13,7 +13,7 @@ export DOWNLOADED_FILENAME='pcre2-${VERSION}.tar.gz'
 
 function download_url_callback() {
     local VERSION="${1}"
-    echo "https://api.github.com/repos/PhilipHazel/pcre2/tarball/pcre2-${VERSION}"
+    echo "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${VERSION}/pcre2-${VERSION}.tar.gz"
 }
 
 function extract_version_callback() {


### PR DESCRIPTION
Reverts cloudfoundry/backup-and-restore-sdk-release#460

The previous url downloaded a copy of the repository source code.
However, the official releases contains additional files and settings.
Mainly, the official releases include a "configure" script that is not
immediately present when downloading the repository source code.