### PR TITLE
Make azure tests work with latest az CLI

### DIFF
--- a/src/azure-blobstore-backup-restore/vendor/system-tests/azure/azure_client.go
+++ b/src/azure-blobstore-backup-restore/vendor/system-tests/azure/azure_client.go
@@ -58,6 +58,7 @@ func (c AzureClient) WriteFileInContainer(container, blobName, body string) stri
 		"storage",
 		"blob",
 		"upload",
+		"--overwrite",
 		"--container-name", container,
 		"--name", blobName,
 		"--file", bodyFile.Name())

--- a/src/system-tests/azure/azure_client.go
+++ b/src/system-tests/azure/azure_client.go
@@ -58,6 +58,7 @@ func (c AzureClient) WriteFileInContainer(container, blobName, body string) stri
 		"storage",
 		"blob",
 		"upload",
+		"--overwrite",
 		"--container-name", container,
 		"--name", blobName,
 		"--file", bodyFile.Name())


### PR DESCRIPTION
According to the release notes of 2022-03-03, there has been a
breaking bugfix to the azure CLI[1]. The old CLI incorrectly assumed
that all writes to azure storage containers ought to be `--overwrite`
writes. In fact, the user should have to specify `--overwrite`
explicitly.

In our azure system tests, we often overwrite the contents of a given
azure storage container, so as to check if the old value was
successfully backed up[2]. We now have to specify `--overwrite`
explicitly.

[1] https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli#march-03-2022

[2] At the time of writing this commit, every test in
    azure_blobstore_system_test.go overwrites the file `fileName2` with
    the contents `TEST_BLOB_2_NEW` after taking a backup.