### PR TITLE
[ci] skip commits with [ci skip] label

### DIFF
--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -215,6 +215,7 @@ resources:
     uri: git@github.com:cloudfoundry/backup-and-restore-sdk-release.git
     private_key: ((github.ssh_key))
     branch: main
+    disable_ci_skip: true
 
 - name: every-2-weeks
   type: time


### PR DESCRIPTION
Our pipeline currently only releases if there has been any changes to
the main branch.

Or at least it should.

We discovered that's not the case because the CI release
[1.18.35](https://github.com/cloudfoundry/backup-and-restore-sdk-release/releases/tag/untagged-ce03efe0e8897b638ab4)
but there were no new commits since `1.18.34`, except the for the [final
release
commit](https://github.com/cloudfoundry/backup-and-restore-sdk-release/commit/69e4ce84b7c154689150f42de553fa3dbc9090ef).

We are now instructing the git-resource to skip commits that have the
`[ci skip]` label to prevent this from happening again in the future.

Signed-off-by: Diego Lemos <dlemos@vmware.com>