### PR TITLE
Adding support to compile openssl 1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,6 +18,10 @@ mysql/mysql-5.7.37.tar.gz:
   size: 56248775
   object_id: bda6d410-4f86-42b3-600a-7705c210ee57
   sha: sha256:a99a9aa8635d2566dab764b2de56bed1730365d360e20bb27f56392ce54e18bd
+openssl/openssl-1.1.1o.tar.gz:
+  size: 9856386
+  object_id: 49453dd9-155f-49c7-4e90-c7fd6293c02f
+  sha: sha256:9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
 postgres/postgresql-9.4.26.tar.gz:
   size: 22001828
   object_id: e89adb5b-a26e-4dc2-5898-616fa1f5d2b6

--- a/packages/database-backup-restorer-mariadb/packaging
+++ b/packages/database-backup-restorer-mariadb/packaging
@@ -36,6 +36,7 @@ tar xzf mariadb/mariadb-${MARIADB_VERSION}.tar.gz
 
   cmake .. \
       -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET} \
+      -DCMAKE_PREFIX_PATH=/var/vcap/packages/libopenssl1 \
       -DWITHOUT_SERVER=ON \
       -DWITH_SSL=system \
       -DWITH_WSREP=ON \

--- a/packages/database-backup-restorer-mariadb/spec
+++ b/packages/database-backup-restorer-mariadb/spec
@@ -19,6 +19,7 @@ name: database-backup-restorer-mariadb
 
 dependencies:
 - libpcre2
+- libopenssl1
 
 files:
 - mariadb/mariadb-10.6.8.tar.gz

--- a/packages/database-backup-restorer-mysql-5.6/packaging
+++ b/packages/database-backup-restorer-mysql-5.6/packaging
@@ -31,6 +31,7 @@ tar xzf mysql/mysql-${MYSQL_VERSION}.tar.gz
   cmake .. \
       -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET} \
       -DWITHOUT_SERVER=ON \
+      -DCMAKE_PREFIX_PATH=/var/vcap/packages/libopenssl1 \
       -DWITH_SSL=system \
       -DWITH_WSREP=ON \
       -DWITH_INNODB_DISALLOW_WRITES=1 \

--- a/packages/database-backup-restorer-mysql-5.6/spec
+++ b/packages/database-backup-restorer-mysql-5.6/spec
@@ -17,7 +17,8 @@
 ---
 name: database-backup-restorer-mysql-5.6
 
-dependencies: []
+dependencies:
+- libopenssl1
 
 files:
 - mysql/mysql-5.6.51.tar.gz

--- a/packages/database-backup-restorer-mysql-5.7/packaging
+++ b/packages/database-backup-restorer-mysql-5.7/packaging
@@ -45,6 +45,7 @@ tar xzf mysql/mysql-${MYSQL_VERSION}.tar.gz
 
   cmake .. \
       -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET} \
+      -DCMAKE_PREFIX_PATH=/var/vcap/packages/libopenssl1 \
       -DWITHOUT_SERVER=ON \
       -DWITH_SSL=system \
       -DWITH_WSREP=ON \

--- a/packages/libopenssl1/packaging
+++ b/packages/libopenssl1/packaging
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright (C) 2017-Present Pivotal Software, Inc. All rights reserved.
 #
 # This program and the accompanying materials are made available under
@@ -13,13 +14,13 @@
 #
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 
----
-name: database-backup-restorer-mysql-5.7
+OPENSSL_VERSION=1.1.1o
 
-dependencies: 
-- database-backup-restorer-boost
-- libopenssl1
+tar xzf openssl/openssl-${OPENSSL_VERSION}.tar.gz
 
-files:
-- mysql/mysql-5.7.37.tar.gz
+cd openssl-${OPENSSL_VERSION}
+./config --prefix=${BOSH_INSTALL_TARGET}
+make
+make install

--- a/packages/libopenssl1/spec
+++ b/packages/libopenssl1/spec
@@ -1,0 +1,7 @@
+---
+name: libopenssl1
+
+dependencies: []
+
+files:
+- openssl/openssl-1.1.1o.tar.gz


### PR DESCRIPTION
This PR builds on #653 , but adds one extra commit that required blobstore privileges. With that extra commit, this PR ought to be able to flow through our CI and auto-merge.

Here's the @lnguyen's text from the original PR:
> Hello! This PR compiles openssl1 with mysql. The default for Jammy is openssl3 and that isn't support for mysql 5.6, 5.7 and the mariadb in this repo. This will add openssl lib to be used to compile mysql. This should work for all OS. The blob still needs to be added and can be found here `https://www.openssl.org/source/openssl-1.1.1o.tar.gz` and using the command `bosh add-blob openssl-1.1.1o.tar.gz openssl/openssl-1.1.1o.tar.gz`
