### PR TITLE
Add job for manually triggering a new release

### DIFF
--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -93,6 +93,7 @@ groups:
   - bump-libpcre2
 - name: shipit
   jobs:
+  - force-a-new-release
   - check-for-changes
   - create-final-patch
 
@@ -857,9 +858,17 @@ jobs:
   - put: version
     params: {file: version/number}
 
+- name: force-a-new-release
+  plan:
+  - put: every-2-weeks
+
 - name: check-for-changes
   plan:
   - in_parallel:
+    - get: force-a-new-release
+      resource: every-2-weeks
+      passed: [force-a-new-release]
+      trigger: true
     - get: every-2-weeks
       trigger: true
     - get: backup-and-restore-sdk-release-main


### PR DESCRIPTION
[#181931122]

We could have achieved a similar result by just manually triggering a new build
for `create-final-patch` job. The downside of that would have been that resource
`every-two-weeks` doesn't get updated. So the pipeline would end up triggering
an automated release in lass than two weeks, as if the manual release had never
happened.

This change adds a new fully manual job named `force-a-new-release` which simply
updates the `two-weeks-resource` creating a new version immediately with the
current date and time. This effectively triggers the creation of a new release
and updates the `every-two-weeks` scheduler to not create an automated release
until two weeks have passed.