### PR TITLE
Feature/mysql 8 support

### DIFF
--- a/ci/manifests/mysql.yml
+++ b/ci/manifests/mysql.yml
@@ -44,16 +44,6 @@ instance_groups:
   jobs:
   - name: bpm
     release: bpm
-  - name: cluster-health-logger
-    release: pxc
-    properties:
-      db_password: foo
-  - name: galera-agent
-    release: pxc
-    properties:
-      db_password: foo
-      endpoint_username: galera_healthcheck
-      endpoint_password: foo
   - name: pxc-mysql
     release: pxc
     properties:
@@ -62,6 +52,8 @@ instance_groups:
       monit_startup_timeout: 120
       remote_admin_access: true
       tls:
+        client:
+          ca: ((databases.ca))
         server:
           ca: ((databases.ca))
           certificate: ((databases.certificate))
@@ -71,9 +63,11 @@ instance_groups:
 variables:
 - name: databases
   type: certificate
+  update_mode: converge
   options:
     is_ca: true
     common_name: mysql
+    alternative_names: ["q-s0.mysql.default.mysql.bosh"]
 
 update:
   canaries: 1

--- a/ci/manifests/ops-files/dev-release.yml
+++ b/ci/manifests/ops-files/dev-release.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /releases/name=backup-and-restore-sdk
+  value:
+    name: backup-and-restore-sdk
+    version: create
+    url: .

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,6 +18,9 @@ mysql/mysql-5.7.38.tar.gz:
   size: 56247722
   object_id: fc5eb46b-585b-455a-70c5-f174d518e490
   sha: sha256:22bf87eefa975b92b54d7c72fb5f3772c657cb0eb055bc6aea65d3a75f69a356
+mysql/mysql-boost-8.0.30.tar.gz:
+  size: 332772783
+  sha: sha256:c331ac7a68099a2116097acbb14fd331423d486fe47ce0e346925111b44df69c
 openssl/openssl-1.1.1o.tar.gz:
   size: 9856386
   object_id: 49453dd9-155f-49c7-4e90-c7fd6293c02f

--- a/jobs/database-backup-restorer/spec
+++ b/jobs/database-backup-restorer/spec
@@ -31,5 +31,6 @@ packages:
 - database-backup-restorer-mariadb
 - database-backup-restorer-mysql-5.6
 - database-backup-restorer-mysql-5.7
+- database-backup-restorer-mysql-8.0
 
 properties: {}

--- a/jobs/database-backup-restorer/templates/backup
+++ b/jobs/database-backup-restorer/templates/backup
@@ -44,4 +44,7 @@ export MYSQL_CLIENT_5_6_PATH="/var/vcap/packages/database-backup-restorer-mysql-
 export MYSQL_DUMP_5_7_PATH="/var/vcap/packages/database-backup-restorer-mysql-5.7/bin/mysqldump"
 export MYSQL_CLIENT_5_7_PATH="/var/vcap/packages/database-backup-restorer-mysql-5.7/bin/mysql"
 
+export MYSQL_DUMP_8_0_PATH="/var/vcap/packages/database-backup-restorer-mysql-8.0/bin/mysqldump"
+export MYSQL_CLIENT_8_0_PATH="/var/vcap/packages/database-backup-restorer-mysql-8.0/bin/mysql"
+
 /var/vcap/packages/database-backup-restorer/bin/database-backup-restore --backup $*

--- a/jobs/database-backup-restorer/templates/restore
+++ b/jobs/database-backup-restorer/templates/restore
@@ -47,4 +47,7 @@ export MYSQL_CLIENT_5_6_PATH="/var/vcap/packages/database-backup-restorer-mysql-
 export MYSQL_DUMP_5_7_PATH="/var/vcap/packages/database-backup-restorer-mysql-5.7/bin/mysqldump"
 export MYSQL_CLIENT_5_7_PATH="/var/vcap/packages/database-backup-restorer-mysql-5.7/bin/mysql"
 
+export MYSQL_DUMP_8_0_PATH="/var/vcap/packages/database-backup-restorer-mysql-8.0/bin/mysqldump"
+export MYSQL_CLIENT_8_0_PATH="/var/vcap/packages/database-backup-restorer-mysql-8.0/bin/mysql"
+
 /var/vcap/packages/database-backup-restorer/bin/database-backup-restore --restore $*

--- a/packages/database-backup-restorer-mysql-8.0/packaging
+++ b/packages/database-backup-restorer-mysql-8.0/packaging
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+tar -xf mysql/mysql-boost-8.0.*.tar.gz
+cd mysql-8.0.*/
+mkdir bld
+cd bld
+
+# NOTE: MySQL 8.0.27+ requires GCC 7.1 or Clang 5 at a minimum.
+#       This means compilation will fail on an ubuntu-xenial stemcell which only provides GCC 5.4
+cmake .. \
+    -DBUILD_CONFIG=mysql_release \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++ \
+    -DCMAKE_INSTALL_PREFIX="${BOSH_INSTALL_TARGET}" \
+    -DINSTALL_STATIC_LIBRARIES=OFF \
+    -DWITHOUT_SERVER=ON \
+    -DWITH_BOOST=../boost/
+make install/strip -j "$(nproc)"

--- a/packages/database-backup-restorer-mysql-8.0/packaging
+++ b/packages/database-backup-restorer-mysql-8.0/packaging
@@ -2,17 +2,21 @@
 
 set -e
 
+apt-get update
+apt-get install -y lsb-release
+codename=$(lsb_release -c -s)
+if [ "${codename}" == "xenial" ]; then
+  echo "MySQL 8.0.27+ requires GCC 7.1 or Clang 5 at a minimum. This means compilation will fail on an ubuntu-xenial stemcell which only provides GCC 5.4"
+  exit 0
+fi
+
 tar -xf mysql/mysql-boost-8.0.*.tar.gz
 cd mysql-8.0.*/
 mkdir bld
 cd bld
 
-# NOTE: MySQL 8.0.27+ requires GCC 7.1 or Clang 5 at a minimum.
-#       This means compilation will fail on an ubuntu-xenial stemcell which only provides GCC 5.4\
 
 
-# if xenial
-# build the failing binary
 cmake .. \
     -DBUILD_CONFIG=mysql_release \
     -DCMAKE_C_COMPILER=gcc \

--- a/packages/database-backup-restorer-mysql-8.0/packaging
+++ b/packages/database-backup-restorer-mysql-8.0/packaging
@@ -8,7 +8,11 @@ mkdir bld
 cd bld
 
 # NOTE: MySQL 8.0.27+ requires GCC 7.1 or Clang 5 at a minimum.
-#       This means compilation will fail on an ubuntu-xenial stemcell which only provides GCC 5.4
+#       This means compilation will fail on an ubuntu-xenial stemcell which only provides GCC 5.4\
+
+
+# if xenial
+# build the failing binary
 cmake .. \
     -DBUILD_CONFIG=mysql_release \
     -DCMAKE_C_COMPILER=gcc \

--- a/packages/database-backup-restorer-mysql-8.0/spec
+++ b/packages/database-backup-restorer-mysql-8.0/spec
@@ -1,0 +1,7 @@
+---
+name: database-backup-restorer-mysql-8.0
+
+dependencies: []
+
+files:
+- mysql/mysql-boost-8.0.*.tar.gz

--- a/scripts/autobump-mysql.sh
+++ b/scripts/autobump-mysql.sh
@@ -9,20 +9,20 @@ ALL_VERSIONS="$(echo "${VALUES}" | grep -Eo '[0-9]+(\.[0-9]+){1,2}[a-zA-Z]?')"
 
 export BLOBS_PREFIX="mysql"
 export ALL_VERSIONS
-export DOWNLOADED_FILENAME='mysql-${VERSION}.tar.gz'
+export DOWNLOADED_FILENAME='mysql-${VERSION/8.0/boost-8.0}.tar.gz'
 
 function checksum_callback() {
     VERSION="${1}"
     DOWNLOADED_FILE="${2}"
 
     CHECKSUM_HTML="$(curl -s -L "https://downloads.mysql.com/archives/community/?version=${VERSION}&os=src&osva=Generic+Linux+%28Architecture+Independent%29#downloads")"
-    EXPECTED_MD5="$(echo "${CHECKSUM_HTML}" | xmllint --html --xpath "//td[a/@href='/archives/gpg/?file=mysql-${VERSION}.tar.gz&p=23']/code/text()" - 2>/dev/null)"
+    EXPECTED_MD5="$(echo "${CHECKSUM_HTML}" | xmllint --html --xpath "//td[a/@href='/archives/gpg/?file=mysql-${VERSION/8.0/boost-8.0}.tar.gz&p=23']/code/text()" - 2>/dev/null)"
     echo "${EXPECTED_MD5}  ${DOWNLOADED_FILE}" | md5sum -c - || exit 1
 }
 
 function download_url_callback() {
     local VERSION="${1}"
-    echo "https://downloads.mysql.com/archives/get/p/23/file/mysql-${VERSION}.tar.gz"
+    echo "https://downloads.mysql.com/archives/get/p/23/file/mysql-${VERSION/8.0/boost-8.0}.tar.gz"
 }
 
 function new_version_callback() {

--- a/src/database-backup-restore/cmd/database-backup-restore/main.go
+++ b/src/database-backup-restore/cmd/database-backup-restore/main.go
@@ -61,7 +61,7 @@ func makeInteractor(isRestoreAction bool, utilitiesConfig config.UtilitiesConfig
 	connectionConfig config.ConnectionConfig, tempFolderManager config.TempFolderManager) (database.Interactor, error) {
 
 	postgresServerVersionDetector := postgres.NewServerVersionDetector(utilitiesConfig.Postgres96.Client)
-	mysqlServerVersionDetector := mysql.NewServerVersionDetector(utilitiesConfig.Mysql80.Client)
+	mysqlServerVersionDetector := mysql.NewServerVersionDetector(utilitiesConfig.Mysql57.Client)
 	interactorFactory := database.NewInteractorFactory(utilitiesConfig, postgresServerVersionDetector, mysqlServerVersionDetector, tempFolderManager)
 	return interactorFactory.Make(actionLabel(isRestoreAction), connectionConfig)
 }

--- a/src/database-backup-restore/cmd/database-backup-restore/main.go
+++ b/src/database-backup-restore/cmd/database-backup-restore/main.go
@@ -61,7 +61,7 @@ func makeInteractor(isRestoreAction bool, utilitiesConfig config.UtilitiesConfig
 	connectionConfig config.ConnectionConfig, tempFolderManager config.TempFolderManager) (database.Interactor, error) {
 
 	postgresServerVersionDetector := postgres.NewServerVersionDetector(utilitiesConfig.Postgres96.Client)
-	mysqlServerVersionDetector := mysql.NewServerVersionDetector(utilitiesConfig.Mysql57.Client)
+	mysqlServerVersionDetector := mysql.NewServerVersionDetector(utilitiesConfig.Mysql80.Client)
 	interactorFactory := database.NewInteractorFactory(utilitiesConfig, postgresServerVersionDetector, mysqlServerVersionDetector, tempFolderManager)
 	return interactorFactory.Make(actionLabel(isRestoreAction), connectionConfig)
 }

--- a/src/database-backup-restore/config/utilities.go
+++ b/src/database-backup-restore/config/utilities.go
@@ -20,6 +20,7 @@ type UtilitiesConfig struct {
 	Mariadb    UtilityPaths
 	Mysql56    UtilityPaths
 	Mysql57    UtilityPaths
+	Mysql80    UtilityPaths
 }
 
 func GetUtilitiesConfigFromEnv() UtilitiesConfig {
@@ -63,6 +64,11 @@ func GetUtilitiesConfigFromEnv() UtilitiesConfig {
 			Client:  lookupEnv("MYSQL_CLIENT_5_7_PATH"),
 			Dump:    lookupEnv("MYSQL_DUMP_5_7_PATH"),
 			Restore: lookupEnv("MYSQL_CLIENT_5_7_PATH"),
+		},
+		Mysql80: UtilityPaths{
+			Client:  lookupEnv("MYSQL_CLIENT_8_0_PATH"),
+			Dump:    lookupEnv("MYSQL_DUMP_8_0_PATH"),
+			Restore: lookupEnv("MYSQL_CLIENT_8_0_PATH"),
 		},
 	}
 }

--- a/src/database-backup-restore/database/interactor_factory.go
+++ b/src/database-backup-restore/database/interactor_factory.go
@@ -121,15 +121,20 @@ func (f InteractorFactory) getUtilitiesForMySQL(mysqlVersion version.DatabaseSer
 		if mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("5", "7", "20")) {
 			return f.utilitiesConfig.Mysql57.Dump, f.utilitiesConfig.Mysql57.Restore, nil
 		}
+		if mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("8", "0", "0")) {
+			return f.utilitiesConfig.Mysql80.Dump, f.utilitiesConfig.Mysql80.Restore, nil
+		}
 	}
 
 	return "", "", fmt.Errorf("unsupported version of %s: %s.%s", implementation, semVer.Major, semVer.Minor)
 }
 
 func (f InteractorFactory) getSSLCommandProvider(mysqlVersion version.DatabaseServerVersion) mysql.SSLOptionsProvider {
-	if mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("5", "7", "20")) {
+	switch {
+	case mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("5", "7", "20")),
+		mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("8", "0", "0")):
 		return mysql.NewDefaultSSLProvider(f.tempFolderManager)
-	} else {
+	default:
 		return mysql.NewLegacySSLOptionsProvider(f.tempFolderManager)
 	}
 }

--- a/src/database-backup-restore/database/interactor_factory.go
+++ b/src/database-backup-restore/database/interactor_factory.go
@@ -1,7 +1,9 @@
 package database
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"database-backup-restore/config"
 	"database-backup-restore/mysql"
@@ -122,6 +124,9 @@ func (f InteractorFactory) getUtilitiesForMySQL(mysqlVersion version.DatabaseSer
 			return f.utilitiesConfig.Mysql57.Dump, f.utilitiesConfig.Mysql57.Restore, nil
 		}
 		if mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("8", "0", "0")) {
+			if _, err := os.Stat(f.utilitiesConfig.Mysql80.Client) ; os.IsNotExist(err) {
+				return "", "", errors.New("MySQL 8.0 is not supported for xenial stemcells.")
+			}
 			return f.utilitiesConfig.Mysql80.Dump, f.utilitiesConfig.Mysql80.Restore, nil
 		}
 	}

--- a/src/database-backup-restore/integration_tests/database_backup_and_restore_suite_test.go
+++ b/src/database-backup-restore/integration_tests/database_backup_and_restore_suite_test.go
@@ -17,12 +17,13 @@
 package integration_tests
 
 import (
+	"testing"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	binmock "github.com/pivotal-cf-experimental/go-binmock"
-
-	"testing"
+	"github.com/pivotal-cf-experimental/go-binmock"
 )
 
 func TestDatabaseBackupAndRestore(t *testing.T) {
@@ -50,6 +51,8 @@ var fakeMysqlClient56 *binmock.Mock
 var fakeMysqlDump56 *binmock.Mock
 var fakeMysqlClient57 *binmock.Mock
 var fakeMysqlDump57 *binmock.Mock
+var fakeMysqlClient80 *binmock.Mock
+var fakeMysqlDump80 *binmock.Mock
 var fakeMariaDBClient *binmock.Mock
 var fakeMariaDBDump *binmock.Mock
 
@@ -78,6 +81,8 @@ var _ = BeforeSuite(func() {
 	fakeMysqlClient56 = binmock.NewBinMock(Fail)
 	fakeMysqlDump57 = binmock.NewBinMock(Fail)
 	fakeMysqlClient57 = binmock.NewBinMock(Fail)
+	fakeMysqlDump80 = binmock.NewBinMock(Fail)
+	fakeMysqlClient80 = binmock.NewBinMock(Fail)
 	fakeMariaDBClient = binmock.NewBinMock(Fail)
 	fakeMariaDBDump = binmock.NewBinMock(Fail)
 })
@@ -102,5 +107,7 @@ var _ = BeforeEach(func() {
 		"MYSQL_DUMP_5_6_PATH":   "non-existent",
 		"MYSQL_CLIENT_5_7_PATH": "non-existent",
 		"MYSQL_DUMP_5_7_PATH":   "non-existent",
+		"MYSQL_CLIENT_8_0_PATH": "non-existent",
+		"MYSQL_DUMP_8_0_PATH":   "non-existent",
 	}
 })

--- a/src/database-backup-restore/integration_tests/database_backup_and_restore_suite_test.go
+++ b/src/database-backup-restore/integration_tests/database_backup_and_restore_suite_test.go
@@ -54,6 +54,8 @@ var fakeMariaDBClient *binmock.Mock
 var fakeMariaDBDump *binmock.Mock
 
 var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(5 * time.Second)
+
 	var err error
 	compiledSDKPath, err = gexec.Build(
 		"database-backup-restore/cmd/database-backup-restore")

--- a/src/database-backup-restore/integration_tests/mysql_test.go
+++ b/src/database-backup-restore/integration_tests/mysql_test.go
@@ -18,11 +18,10 @@ package integration_tests
 
 import (
 	"fmt"
-	"os/exec"
-
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -41,13 +40,588 @@ var _ = Describe("MySQL", func() {
 	var err error
 	var configFile *os.File
 
+	Context("mysql 8.0", func() {
+		BeforeEach(func() {
+			artifactFile = tempFilePath()
+			fakeMysqlDump80.Reset()
+			fakeMysqlClient80.Reset()
+
+			envVars["MYSQL_CLIENT_8_0_PATH"] = fakeMysqlClient80.Path
+			envVars["MYSQL_DUMP_8_0_PATH"] = fakeMysqlDump80.Path
+		})
+
+		Context("backup", func() {
+			BeforeEach(func() {
+				configFile = saveFile(fmt.Sprintf(`{
+					"adapter":  "mysql",
+					"username": "%s",
+					"password": "%s",
+					"host":     "%s",
+					"port":     %d,
+					"database": "%s"
+				}`,
+					username,
+					password,
+					host,
+					port,
+					databaseName))
+			})
+
+			JustBeforeEach(func() {
+				cmd := exec.Command(
+					compiledSDKPath,
+					"--artifact-file",
+					artifactFile,
+					"--config",
+					configFile.Name(),
+					"--backup")
+
+				for key, val := range envVars {
+					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
+				}
+
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit())
+			})
+
+			Context("when mysqldump succeeds", func() {
+				BeforeEach(func() {
+					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("MYSQL server version 8.0.27")
+					fakeMysqlDump80.WhenCalled().WillExitWith(0)
+				})
+
+				It("calls mysql and mysqldump with the correct arguments", func() {
+					Expect(session).Should(gexec.Exit(0), `Expected success?`)
+
+					By("calling mysql to detect the version", func() {
+						Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+						Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+							fmt.Sprintf("--user=%s", username),
+							fmt.Sprintf("--host=%s", host),
+							fmt.Sprintf("--port=%d", port),
+							"--skip-column-names",
+							"--silent",
+							`--execute=SELECT VERSION()`,
+						))
+						Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					})
+
+					By("then calling dump", func() {
+						Expect(fakeMysqlDump80.Invocations()).To(HaveLen(1))
+						expectedArgs := []string{
+							fmt.Sprintf("--user=%s", username),
+							fmt.Sprintf("--host=%s", host),
+							fmt.Sprintf("--port=%d", port),
+							"-v",
+							"--single-transaction",
+							"--skip-add-locks",
+							"--set-gtid-purged=OFF",
+							fmt.Sprintf("--result-file=%s", artifactFile),
+							databaseName,
+						}
+
+						Expect(fakeMysqlDump80.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+						Expect(fakeMysqlDump80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					})
+
+					Expect(session).Should(gexec.Exit(0))
+				})
+
+				Context("when 'tables' are specified in the configFile", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+					"adapter":  "mysql",
+					"username": "%s",
+					"password": "%s",
+					"host":     "%s",
+					"port":     %d,
+					"database": "%s",
+					"tables": ["table1", "table2", "table3"]
+				}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysqldump with the correct arguments", func() {
+						expectedArgs := []string{
+							fmt.Sprintf("--user=%s", username),
+							fmt.Sprintf("--host=%s", host),
+							fmt.Sprintf("--port=%d", port),
+							"-v",
+							"--single-transaction",
+							"--set-gtid-purged=OFF",
+							"--skip-add-locks",
+							fmt.Sprintf("--result-file=%s", artifactFile),
+							databaseName,
+							"table1",
+							"table2",
+							"table3",
+						}
+
+						Expect(fakeMysqlDump80.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+					})
+				})
+
+				Context("when TLS is configured", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+							"adapter":  "mysql",
+							"username": "%s",
+							"password": "%s",
+							"host":     "%s",
+							"port":     %d,
+							"database": "%s",
+							"tls": {
+								"cert": {
+									"ca": "A_CA_CERT"
+								}
+							}
+						}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysql and mysqldump with the correct arguments", func() {
+						By("calling mysql to detect the version", func() {
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("then calling dump", func() {
+							expectedArgs := []interface{}{
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"-v",
+								"--set-gtid-purged=OFF",
+								"--single-transaction",
+								"--skip-add-locks",
+								fmt.Sprintf("--result-file=%s", artifactFile),
+								databaseName,
+							}
+
+							Expect(fakeMysqlDump80.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+						})
+					})
+				})
+
+				Context("when TLS is configured with client cert and private key", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+							"adapter":  "mysql",
+							"username": "%s",
+							"password": "%s",
+							"host":     "%s",
+							"port":     %d,
+							"database": "%s",
+							"tls": {
+								"cert": {
+									"ca": "A_CA_CERT",
+									"certificate": "A_CLIENT_CERT",
+									"private_key": "A_CLIENT_KEY"
+								}
+							}
+						}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysql and mysqldump with the correct arguments", func() {
+						By("calling mysql to detect the version", func() {
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								HavePrefix("--ssl-cert="),
+								HavePrefix("--ssl-key="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
+								HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("then calling dump", func() {
+							expectedArgs := []interface{}{
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								HavePrefix("--ssl-cert="),
+								HavePrefix("--ssl-key="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"-v",
+								"--single-transaction",
+								"--set-gtid-purged=OFF",
+								"--skip-add-locks",
+								fmt.Sprintf("--result-file=%s", artifactFile),
+								databaseName,
+							}
+
+							Expect(fakeMysqlDump80.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+						})
+					})
+				})
+			})
+
+			Context("when version detection fails", func() {
+				BeforeEach(func() {
+					fakeMysqlClient80.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillExitWith(1).WillPrintToStdErr("VERSION DETECTION FAILED!")
+				})
+
+				It("also fails", func() {
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Eventually(session).Should(gexec.Exit(1))
+					Expect(session.Err).To(gbytes.Say("VERSION DETECTION FAILED!"))
+				})
+			})
+
+			Context("when mysqldump fails", func() {
+				BeforeEach(func() {
+					fakeMysqlClient80.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 8.0.27")
+					fakeMysqlDump80.WhenCalled().WillExitWith(1)
+				})
+
+				It("also fails", func() {
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Eventually(session).Should(gexec.Exit(1))
+				})
+			})
+
+			Context("when the server has an unsupported mysql major version", func() {
+				BeforeEach(func() {
+					fakeMysqlClient80.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 4.7.20")
+				})
+
+				It("fails because of a version mismatch", func() {
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(session).Should(gexec.Exit(1))
+					Expect(string(session.Err.Contents())).Should(ContainSubstring(
+						"unsupported version of mysql: 4.7"),
+					)
+				})
+			})
+
+			Context("when the server has an unsupported mysql minor version", func() {
+				BeforeEach(func() {
+					fakeMysqlClient80.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 8.9.20")
+				})
+
+				It("fails because of a version mismatch", func() {
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(session).Should(gexec.Exit(1))
+					Expect(string(session.Err.Contents())).Should(ContainSubstring(
+						"unsupported version of mysql: 8.9"),
+					)
+				})
+			})
+
+			Context("when the server has a supported mysql minor version with a different patch to the packaged utility", func() {
+				BeforeEach(func() {
+					fakeMysqlDump80.WhenCalled().WillExitWith(0)
+					fakeMysqlClient80.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 8.0.5")
+				})
+
+				It("succeeds despite different patch versions", func() {
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(session).Should(gexec.Exit(0))
+				})
+			})
+		})
+
+		Context("restore", func() {
+			BeforeEach(func() {
+				configFile = saveFile(fmt.Sprintf(`{
+					"adapter":  "mysql",
+					"username": "%s",
+					"password": "%s",
+					"host":     "%s",
+					"port":     %d,
+					"database": "%s"
+				}`,
+					username,
+					password,
+					host,
+					port,
+					databaseName))
+			})
+
+			JustBeforeEach(func() {
+				err := ioutil.WriteFile(artifactFile, []byte("SOME BACKUP SQL"), 0644)
+				if err != nil {
+					log.Fatalf("Failed to write to artifact file, %s\n", err.Error())
+				}
+
+				cmd := exec.Command(
+					compiledSDKPath,
+					"--artifact-file",
+					artifactFile,
+					"--config",
+					configFile.Name(),
+					"--restore")
+
+				for key, val := range envVars {
+					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
+				}
+
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit())
+			})
+
+			Context("when mysql succeeds", func() {
+				BeforeEach(func() {
+					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("MYSQL server version 8.0.27")
+					fakeMysqlClient80.WhenCalled().WillExitWith(0)
+				})
+
+				Context("when TLS is not configured", func() {
+					It("calls mysql with the correct arguments", func() {
+						Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
+
+						By("calling mysql with for version check", func() {
+							expectedVersionCheckArgs := []string{
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							}
+
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(expectedVersionCheckArgs))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("calling mysql with for restore", func() {
+							expectedRestoreArgs := []string{
+								"-v",
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								databaseName,
+							}
+
+							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedRestoreArgs))
+							Expect(fakeMysqlClient80.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+							Expect(fakeMysqlClient80.Invocations()[1].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("succeeding", func() {
+							Expect(session).Should(gexec.Exit(0))
+						})
+					})
+				})
+
+				Context("when TLS is configured", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+							"adapter":  "mysql",
+							"username": "%s",
+							"password": "%s",
+							"host":     "%s",
+							"port":     %d,
+							"database": "%s",
+							"tls": {
+								"cert": {
+									"ca": "A_CA_CERT"
+								}
+							}
+						}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysql with the correct arguments", func() {
+						By("calling mysql to detect the version", func() {
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
+								HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("then calling mysql to restore", func() {
+							expectedArgs := []interface{}{
+								"-v",
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								databaseName,
+							}
+
+							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
+						})
+					})
+				})
+
+				Context("when TLS is configured with client cert and private key", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+							"adapter":  "mysql",
+							"username": "%s",
+							"password": "%s",
+							"host":     "%s",
+							"port":     %d,
+							"database": "%s",
+							"tls": {
+								"cert": {
+									"ca": "A_CA_CERT",
+									"certificate": "A_CLIENT_CERT",
+									"private_key": "A_CLIENT_KEY"
+								}
+							}
+						}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysql with the correct arguments", func() {
+						By("calling mysql to detect the version", func() {
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								HavePrefix("--ssl-cert="),
+								HavePrefix("--ssl-key="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
+								HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("then calling mysql to restore", func() {
+							expectedArgs := []interface{}{
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								HavePrefix("--ssl-cert="),
+								HavePrefix("--ssl-key="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"-v",
+								databaseName,
+							}
+
+							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
+							Expect(fakeMysqlClient80.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+						})
+					})
+				})
+			})
+
+			Context("when mysql fails", func() {
+				BeforeEach(func() {
+					fakeMysqlClient80.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 5.7.20")
+					fakeMysqlClient80.WhenCalled().WillExitWith(1)
+				})
+
+				It("also fails", func() {
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Eventually(session).Should(gexec.Exit(1))
+				})
+			})
+		})
+	})
+
 	Context("mysql 5.7", func() {
 		BeforeEach(func() {
 			artifactFile = tempFilePath()
+			fakeMysqlClient80.Reset()
 			fakeMysqlDump57.Reset()
-			fakeMysqlClient57.Reset()
+			fakeMysqlClient80.Reset()
 
-			envVars["MYSQL_CLIENT_5_7_PATH"] = fakeMysqlClient57.Path
+			envVars["MYSQL_CLIENT_8_0_PATH"] = fakeMysqlClient80.Path
+			envVars["MYSQL_CLIENT_5_7_PATH"] = fakeMysqlClient80.Path
 			envVars["MYSQL_DUMP_5_7_PATH"] = fakeMysqlDump57.Path
 		})
 
@@ -88,14 +662,14 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysqldump succeeds", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("MYSQL server version 5.7.20")
+					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("MYSQL server version 5.7.20")
 					fakeMysqlDump57.WhenCalled().WillExitWith(0)
 				})
 
 				It("calls mysql and mysqldump with the correct arguments", func() {
 					By("calling mysql to detect the version", func() {
-						Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-						Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+						Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+						Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 							fmt.Sprintf("--user=%s", username),
 							fmt.Sprintf("--host=%s", host),
 							fmt.Sprintf("--port=%d", port),
@@ -103,7 +677,7 @@ var _ = Describe("MySQL", func() {
 							"--silent",
 							`--execute=SELECT VERSION()`,
 						))
-						Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					})
 
 					By("then calling dump", func() {
@@ -189,8 +763,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql and mysqldump with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -200,7 +774,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
 						By("then calling dump", func() {
@@ -249,8 +823,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql and mysqldump with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -262,7 +836,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -291,7 +865,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when version detection fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -302,7 +876,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 					Expect(session.Err).To(gbytes.Say("VERSION DETECTION FAILED!"))
 				})
@@ -310,7 +884,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysqldump fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -322,14 +896,14 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 				})
 			})
 
 			Context("when the server has an unsupported mysql major version", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -340,7 +914,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("fails because of a version mismatch", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(1))
 					Expect(string(session.Err.Contents())).Should(ContainSubstring(
 						"unsupported version of mysql: 4.7"),
@@ -350,7 +924,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when the server has an unsupported mysql minor version", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -361,7 +935,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("fails because of a version mismatch", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(1))
 					Expect(string(session.Err.Contents())).Should(ContainSubstring(
 						"unsupported version of mysql: 5.9"),
@@ -372,7 +946,7 @@ var _ = Describe("MySQL", func() {
 			Context("when the server has a supported mysql minor version with a different patch to the packaged utility", func() {
 				BeforeEach(func() {
 					fakeMysqlDump57.WhenCalled().WillExitWith(0)
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -383,7 +957,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("succeeds despite different patch versions", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(0))
 				})
 			})
@@ -431,13 +1005,13 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysql succeeds", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("MYSQL server version 5.7.20")
-					fakeMysqlClient57.WhenCalled().WillExitWith(0)
+					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("MYSQL server version 5.7.20")
+					fakeMysqlClient80.WhenCalled().WillExitWith(0)
 				})
 
 				Context("when TLS is not configured", func() {
 					It("calls mysql with the correct arguments", func() {
-						Expect(fakeMysqlClient57.Invocations()).To(HaveLen(2))
+						Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
 
 						By("calling mysql with for version check", func() {
 							expectedVersionCheckArgs := []string{
@@ -449,8 +1023,8 @@ var _ = Describe("MySQL", func() {
 								`--execute=SELECT VERSION()`,
 							}
 
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(expectedVersionCheckArgs))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(expectedVersionCheckArgs))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
 						By("calling mysql with for restore", func() {
@@ -462,9 +1036,9 @@ var _ = Describe("MySQL", func() {
 								databaseName,
 							}
 
-							Expect(fakeMysqlClient57.Invocations()[1].Args()).Should(ConsistOf(expectedRestoreArgs))
-							Expect(fakeMysqlClient57.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
-							Expect(fakeMysqlClient57.Invocations()[1].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedRestoreArgs))
+							Expect(fakeMysqlClient80.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+							Expect(fakeMysqlClient80.Invocations()[1].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
 						By("succeeding", func() {
@@ -497,8 +1071,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(2))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -508,7 +1082,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -523,7 +1097,7 @@ var _ = Describe("MySQL", func() {
 								databaseName,
 							}
 
-							Expect(fakeMysqlClient57.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
+							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
 						})
 					})
 				})
@@ -554,8 +1128,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(2))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -567,7 +1141,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -584,8 +1158,8 @@ var _ = Describe("MySQL", func() {
 								databaseName,
 							}
 
-							Expect(fakeMysqlClient57.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
-							Expect(fakeMysqlClient57.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
+							Expect(fakeMysqlClient80.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
 						})
 					})
 				})
@@ -593,7 +1167,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysql fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -601,11 +1175,11 @@ var _ = Describe("MySQL", func() {
 						"--silent",
 						`--execute=SELECT VERSION()`,
 					).WillPrintToStdOut("MYSQL server version 5.7.20")
-					fakeMysqlClient57.WhenCalled().WillExitWith(1)
+					fakeMysqlClient80.WhenCalled().WillExitWith(1)
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 				})
 			})
@@ -615,11 +1189,11 @@ var _ = Describe("MySQL", func() {
 	Context("mysql 5.6", func() {
 		BeforeEach(func() {
 			artifactFile = tempFilePath()
-			fakeMysqlClient57.Reset()
+			fakeMysqlClient80.Reset()
 			fakeMysqlDump56.Reset()
 			fakeMysqlClient56.Reset()
 
-			envVars["MYSQL_CLIENT_5_7_PATH"] = fakeMysqlClient57.Path
+			envVars["MYSQL_CLIENT_8_0_PATH"] = fakeMysqlClient80.Path
 			envVars["MYSQL_CLIENT_5_6_PATH"] = fakeMysqlClient56.Path
 			envVars["MYSQL_DUMP_5_6_PATH"] = fakeMysqlDump56.Path
 		})
@@ -661,14 +1235,14 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysqldump succeeds", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("MYSQL server version 5.6.38")
+					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("MYSQL server version 5.6.38")
 					fakeMysqlDump56.WhenCalled().WillExitWith(0)
 				})
 
 				It("calls mysql and mysqldump with the correct arguments", func() {
 					By("calling mysql to detect the version", func() {
-						Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-						Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+						Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+						Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 							fmt.Sprintf("--user=%s", username),
 							fmt.Sprintf("--host=%s", host),
 							fmt.Sprintf("--port=%d", port),
@@ -676,7 +1250,7 @@ var _ = Describe("MySQL", func() {
 							"--silent",
 							`--execute=SELECT VERSION()`,
 						))
-						Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					})
 
 					By("then calling dump", func() {
@@ -765,8 +1339,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql and mysqldump with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -776,7 +1350,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -825,8 +1399,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql and mysqldump with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -838,7 +1412,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -867,7 +1441,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when version detection fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -878,7 +1452,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 					Expect(session.Err).To(gbytes.Say("VERSION DETECTION FAILED!"))
 				})
@@ -886,7 +1460,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysqldump fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -898,14 +1472,14 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 				})
 			})
 
 			Context("when the server has an unsupported mysql major version", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -916,7 +1490,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("fails because of a version mismatch", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(1))
 					Expect(string(session.Err.Contents())).Should(ContainSubstring(
 						"unsupported version of mysql: 4.7"),
@@ -926,7 +1500,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when the server has an unsupported mysql minor version", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -937,7 +1511,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("fails because of a version mismatch", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(1))
 					Expect(string(session.Err.Contents())).Should(ContainSubstring(
 						"unsupported version of mysql: 5.9"),
@@ -948,7 +1522,7 @@ var _ = Describe("MySQL", func() {
 			Context("when the server has a supported mysql minor version with a different patch to the packaged utility", func() {
 				BeforeEach(func() {
 					fakeMysqlDump56.WhenCalled().WillExitWith(0)
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -959,7 +1533,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("succeeds despite different patch versions", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(0))
 				})
 			})
@@ -1007,7 +1581,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysql succeeds", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("MYSQL server version 5.6.38")
+					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("MYSQL server version 5.6.38")
 					fakeMysqlClient56.WhenCalled().WillExitWith(0)
 				})
 
@@ -1022,9 +1596,9 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							}
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(expectedVersionCheckArgs))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(expectedVersionCheckArgs))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
 						By("calling mysql with the correct arguments for restoring", func() {
@@ -1073,8 +1647,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -1084,7 +1658,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
 						By("then calling mysql to restore", func() {
@@ -1130,8 +1704,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -1143,7 +1717,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -1169,7 +1743,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysql fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalledWith(
+					fakeMysqlClient80.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -1181,7 +1755,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 				})
 			})
@@ -1203,10 +1777,10 @@ var _ = Describe("MariaDB", func() {
 	Context("mariadb 10.1", func() {
 		BeforeEach(func() {
 			artifactFile = tempFilePath()
+			fakeMysqlClient80.Reset()
 			fakeMariaDBDump.Reset()
-			fakeMysqlClient57.Reset()
 
-			envVars["MYSQL_CLIENT_5_7_PATH"] = fakeMysqlClient57.Path
+			envVars["MYSQL_CLIENT_8_0_PATH"] = fakeMysqlClient80.Path
 			envVars["MARIADB_DUMP_PATH"] = fakeMariaDBDump.Path
 		})
 
@@ -1247,7 +1821,7 @@ var _ = Describe("MariaDB", func() {
 
 			Context("when mysqldump succeeds", func() {
 				BeforeEach(func() {
-					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("10.1.34-MariaDB")
+					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("10.1.34-MariaDB")
 					fakeMariaDBDump.WhenCalled().WillExitWith(0)
 				})
 

--- a/src/database-backup-restore/system_tests/mysql/mysql_suite_test.go
+++ b/src/database-backup-restore/system_tests/mysql/mysql_suite_test.go
@@ -54,7 +54,7 @@ var _ = Describe("mysql", func() {
 		mysqlClientKey = os.Getenv("MYSQL_CLIENT_KEY")
 
 		connection, proxySession = ConnectMysql(
-			mysqlHostName,
+			resolveHostToIP(brJob, mysqlHostName),
 			mysqlPassword,
 			mysqlNonSslUsername,
 			mysqlPort,


### PR DESCRIPTION
This PR is to add support for mysql 8.0 to BBR. We would like access to CI so we can make changes as necessary.

- Compiling mysql 8 for xenial is not support at the moment. We present the user with an error message if they do try to backup a mysql 8.0 database with bbr compiled against a xenial stemcell.
- [reference slack thread 1](https://vmware.slack.com/archives/C01DXEYRKRU/p1660603529655749)
- [reference slack thread 2](https://vmware.slack.com/archives/C01DXEYRKRU/p1661816508166169)