### PR TITLE
test: log commands before running them

### DIFF
--- a/src/database-backup-restore/integration_tests/database_backup_restore_test.go
+++ b/src/database-backup-restore/integration_tests/database_backup_restore_test.go
@@ -121,6 +121,7 @@ var _ = Describe("Backup and Restore DB Utility", func() {
 				args := strings.Split(entry.arguments, " ")
 				cmd := exec.Command(compiledSDKPath, args...)
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(1))
@@ -174,6 +175,7 @@ var _ = Describe("Backup and Restore DB Utility", func() {
 					}
 				}
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit(1))

--- a/src/database-backup-restore/integration_tests/mysql_test.go
+++ b/src/database-backup-restore/integration_tests/mysql_test.go
@@ -80,6 +80,7 @@ var _ = Describe("MySQL", func() {
 					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 				}
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())
@@ -423,6 +424,7 @@ var _ = Describe("MySQL", func() {
 					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 				}
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())
@@ -653,6 +655,7 @@ var _ = Describe("MySQL", func() {
 					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 				}
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())
@@ -998,6 +1001,7 @@ var _ = Describe("MySQL", func() {
 					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 				}
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())
@@ -1227,6 +1231,7 @@ var _ = Describe("MySQL", func() {
 					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 				}
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())
@@ -1573,6 +1578,7 @@ var _ = Describe("MySQL", func() {
 					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 				}
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())
@@ -1813,6 +1819,7 @@ var _ = Describe("MariaDB", func() {
 					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 				}
 
+				fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())

--- a/src/database-backup-restore/integration_tests/postgres_test.go
+++ b/src/database-backup-restore/integration_tests/postgres_test.go
@@ -1810,6 +1810,7 @@ func run(path string, env map[string]string, args ...string) *gexec.Session {
 	for key, val := range env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
 	}
+	fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).ToNot(HaveOccurred())
 	Eventually(session).Should(gexec.Exit())

--- a/src/database-backup-restore/system_tests/utils/db.go
+++ b/src/database-backup-restore/system_tests/utils/db.go
@@ -176,7 +176,7 @@ func (c *PostgresConnection) connectionString(hostname string, port int, dbName,
 
 func startTunnel(localPort int, remoteHost string, remotePort int, proxyUsername string, proxyHost string, proxyPrivateKey string) (*gexec.Session, error) {
 	var err error
-	proxySession, err := gexec.Start(exec.Command(
+	command := exec.Command(
 		"ssh",
 		"-L",
 		fmt.Sprintf("%d:%s:%d", localPort, remoteHost, remotePort),
@@ -187,7 +187,9 @@ func startTunnel(localPort int, remoteHost string, remotePort int, proxyUsername
 		"UserKnownHostsFile=/dev/null",
 		"-o",
 		"StrictHostKeyChecking=no",
-	), ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	)
+	fmt.Fprintf(ginkgo.GinkgoWriter, "Running command: %s\n", command.String())
+	proxySession, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 
 	time.Sleep(5 * time.Second)
 

--- a/src/database-backup-restore/system_tests/utils/utils.go
+++ b/src/database-backup-restore/system_tests/utils/utils.go
@@ -43,6 +43,7 @@ func RunCommandWithStream(stdout, stderr io.Writer, cmd string, args ...string) 
 	combinedArgs := append(cmdParts[1:], args...)
 	command := exec.Command(commandPath, combinedArgs...)
 
+	fmt.Fprintf(GinkgoWriter, "Running command: %s\n", command.String())
 	session, err := gexec.Start(command, stdout, stderr)
 
 	Expect(err).ToNot(HaveOccurred())

--- a/src/gcs-blobstore-backup-restore/cmd/gcs-blobstore-backup-restore/main_test.go
+++ b/src/gcs-blobstore-backup-restore/cmd/gcs-blobstore-backup-restore/main_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -12,7 +13,9 @@ import (
 
 var _ = Describe("Main", func() {
 	It("fails when neither backup nor restore flag is set", func() {
-		session, err := gexec.Start(exec.Command(binaryPath), GinkgoWriter, GinkgoWriter)
+		command := exec.Command(binaryPath)
+		fmt.Fprintf(GinkgoWriter, "Running command: %s\n", command.String())
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(session).Should(gexec.Exit())
@@ -21,7 +24,9 @@ var _ = Describe("Main", func() {
 	})
 
 	It("fails when both backup nor restore flags are provided", func() {
-		session, err := gexec.Start(exec.Command(binaryPath, "--backup", "--restore"), GinkgoWriter, GinkgoWriter)
+		command := exec.Command(binaryPath, "--backup", "--restore")
+		fmt.Fprintf(GinkgoWriter, "Running command: %s\n", command.String())
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(session).Should(gexec.Exit())

--- a/src/gcs-blobstore-backup-restore/contract_test/gcs_helpers_test.go
+++ b/src/gcs-blobstore-backup-restore/contract_test/gcs_helpers_test.go
@@ -62,6 +62,7 @@ func createTmpFile(dirName, fileName, fileContents string) *os.File {
 
 func runSuccessfully(command string, args ...string) (string, string) {
 	cmd := exec.Command(command, args...)
+	fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(session).Should(gexec.Exit(0))

--- a/src/system-tests/gcs/gcs_suite_test.go
+++ b/src/system-tests/gcs/gcs_suite_test.go
@@ -1,17 +1,15 @@
 package gcs_test
 
 import (
-	"testing"
-
-	"time"
-
-	"os/exec"
-
-	. "system-tests"
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	. "github.com/onsi/gomega/gexec"
+	"os/exec"
+	. "system-tests"
+	"testing"
+	"time"
 )
 
 func TestGcs(t *testing.T) {
@@ -29,6 +27,7 @@ var _ = BeforeSuite(func() {
 func MustRunSuccessfully(command string, args ...string) {
 	cmd := exec.Command(command, args...)
 
+	fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(session).Should(Exit(0))
@@ -37,6 +36,7 @@ func MustRunSuccessfully(command string, args ...string) {
 func Run(command string, args ...string) *gexec.Session {
 	cmd := exec.Command(command, args...)
 
+	fmt.Fprintf(GinkgoWriter, "Running command: %s\n", cmd.String())
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	return session

--- a/src/system-tests/job_instance.go
+++ b/src/system-tests/job_instance.go
@@ -83,6 +83,7 @@ func (i *JobInstance) runBosh(args ...string) *gexec.Session {
 	}, args...)
 	command := exec.Command("bosh", combinedArgs...)
 
+	fmt.Fprintf(GinkgoWriter, "Running command: %s\n", command.String())
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
When running a command in a test, the output from the command is logged if there is a failure, but the command run was not. This change introduces logging of the command run, so that it's easier to reason about what a test was doing when it failed.