### PR TITLE
chore: remove usage of ioutil

### DIFF
--- a/src/azure-blobstore-backup-restore/artifact.go
+++ b/src/azure-blobstore-backup-restore/artifact.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"encoding/json"
-	"io/ioutil"
 )
 
 type Artifact struct {
@@ -14,7 +13,7 @@ func NewArtifact(path string) Artifact {
 }
 
 func (a Artifact) Read() (map[string]ContainerBackup, error) {
-	filesContents, err := ioutil.ReadFile(a.path)
+	filesContents, err := os.ReadFile(a.path)
 	if err != nil {
 		return nil, err
 	}
@@ -34,5 +33,5 @@ func (a Artifact) Write(backups map[string]ContainerBackup) error {
 		return err
 	}
 
-	return ioutil.WriteFile(a.path, filesContents, 0644)
+	return os.WriteFile(a.path, filesContents, 0644)
 }

--- a/src/azure-blobstore-backup-restore/artifact_test.go
+++ b/src/azure-blobstore-backup-restore/artifact_test.go
@@ -1,8 +1,6 @@
 package azure_test
 
 import (
-	"io/ioutil"
-
 	"os"
 
 	"azure-blobstore-backup-restore"
@@ -18,7 +16,7 @@ var _ = Describe("Artifact", func() {
 		Context("when the artifact file is writable", func() {
 			BeforeEach(func() {
 				var err error
-				artifactFile, err = ioutil.TempFile("", "azure_backup")
+				artifactFile, err = os.CreateTemp("", "azure_backup")
 				Expect(err).NotTo(HaveOccurred())
 				artifact = azure.NewArtifact(artifactFile.Name())
 			})
@@ -36,7 +34,7 @@ var _ = Describe("Artifact", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				fileContent, err := ioutil.ReadFile(artifactFile.Name())
+				fileContent, err := os.ReadFile(artifactFile.Name())
 
 				Expect(fileContent).To(MatchJSON(`{
 					"container_id": {
@@ -66,9 +64,9 @@ var _ = Describe("Artifact", func() {
 	Describe("Read", func() {
 		Context("when the artifact file is readable", func() {
 			It("reads the backups", func() {
-				artifactFile, err := ioutil.TempFile("", "azure_restore_artifact")
+				artifactFile, err := os.CreateTemp("", "azure_restore_artifact")
 				Expect(err).NotTo(HaveOccurred())
-				err = ioutil.WriteFile(artifactFile.Name(), []byte(`{
+				err = os.WriteFile(artifactFile.Name(), []byte(`{
 					"container_id": {
 						"name": "container_name",
 						"blobs": [
@@ -108,9 +106,9 @@ var _ = Describe("Artifact", func() {
 
 		Context("when the artifact file is not valid JSON", func() {
 			It("reports an error", func() {
-				artifactFile, err := ioutil.TempFile("", "azure_restore_artifact")
+				artifactFile, err := os.CreateTemp("", "azure_restore_artifact")
 				Expect(err).NotTo(HaveOccurred())
-				err = ioutil.WriteFile(artifactFile.Name(), []byte{}, 0644)
+				err = os.WriteFile(artifactFile.Name(), []byte{}, 0644)
 				Expect(err).NotTo(HaveOccurred())
 
 				artifact = azure.NewArtifact(artifactFile.Name())

--- a/src/azure-blobstore-backup-restore/config.go
+++ b/src/azure-blobstore-backup-restore/config.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"encoding/json"
-	"io/ioutil"
 )
 
 type ContainerConfig struct {
@@ -19,7 +18,7 @@ type RestoreFromConfig struct {
 }
 
 func ParseConfig(configFilePath string) (map[string]ContainerConfig, error) {
-	configContents, err := ioutil.ReadFile(configFilePath)
+	configContents, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/azure-blobstore-backup-restore/config_test.go
+++ b/src/azure-blobstore-backup-restore/config_test.go
@@ -1,8 +1,6 @@
 package azure_test
 
 import (
-	"io/ioutil"
-
 	"os"
 
 	"azure-blobstore-backup-restore"
@@ -17,7 +15,7 @@ var _ = Describe("ParseConfig", func() {
 		var config map[string]azure.ContainerConfig
 
 		BeforeEach(func() {
-			configFile, err = ioutil.TempFile("", "azure_config")
+			configFile, err = os.CreateTemp("", "azure_config")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -29,7 +27,7 @@ var _ = Describe("ParseConfig", func() {
 					"azure_storage_key": "my-storage-key"
 				}
 			}`
-			ioutil.WriteFile(configFile.Name(), []byte(configJson), 0644)
+			os.WriteFile(configFile.Name(), []byte(configJson), 0644)
 
 			config, err = azure.ParseConfig(configFile.Name())
 
@@ -51,7 +49,7 @@ var _ = Describe("ParseConfig", func() {
 						"environment": "my-sovereign-cloud"
 					}
 				}`
-				ioutil.WriteFile(configFile.Name(), []byte(configJson), 0644)
+				os.WriteFile(configFile.Name(), []byte(configJson), 0644)
 
 				config, err = azure.ParseConfig(configFile.Name())
 
@@ -78,7 +76,7 @@ var _ = Describe("ParseConfig", func() {
 						}
 					}
 				}`
-				ioutil.WriteFile(configFile.Name(), []byte(configJson), 0644)
+				os.WriteFile(configFile.Name(), []byte(configJson), 0644)
 
 				config, err = azure.ParseConfig(configFile.Name())
 
@@ -106,9 +104,9 @@ var _ = Describe("ParseConfig", func() {
 
 	Context("when the config file is not valid", func() {
 		It("returns an error", func() {
-			configFile, err := ioutil.TempFile("", "azure_config")
+			configFile, err := os.CreateTemp("", "azure_config")
 			Expect(err).NotTo(HaveOccurred())
-			ioutil.WriteFile(configFile.Name(), []byte{}, 0000)
+			os.WriteFile(configFile.Name(), []byte{}, 0000)
 
 			_, err = azure.ParseConfig(configFile.Name())
 

--- a/src/database-backup-restore/config/connection.go
+++ b/src/database-backup-restore/config/connection.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 type ConnectionConfig struct {
@@ -29,7 +28,7 @@ type CertTlsConfig struct {
 }
 
 func ParseAndValidateConnectionConfig(configPath string) (ConnectionConfig, error) {
-	configString, err := ioutil.ReadFile(configPath)
+	configString, err := os.ReadFile(configPath)
 	if err != nil {
 		return ConnectionConfig{}, fmt.Errorf("Fail reading config file: %s\n", err)
 	}

--- a/src/database-backup-restore/config/temp_folder_manager.go
+++ b/src/database-backup-restore/config/temp_folder_manager.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -10,7 +9,7 @@ type TempFolderManager struct {
 }
 
 func NewTempFolderManager() (TempFolderManager, error) {
-	folderPath, err := ioutil.TempDir("", "")
+	folderPath, err := os.MkdirTemp("", "")
 	if err != nil {
 		return TempFolderManager{}, err
 	}
@@ -18,12 +17,12 @@ func NewTempFolderManager() (TempFolderManager, error) {
 }
 
 func (m TempFolderManager) WriteTempFile(contents string) (string, error) {
-	file, err := ioutil.TempFile(m.folderPath, "")
+	file, err := os.CreateTemp(m.folderPath, "")
 	if err != nil {
 		return "", err
 	}
 
-	err = ioutil.WriteFile(file.Name(), []byte(contents), 0777)
+	err = os.WriteFile(file.Name(), []byte(contents), 0777)
 	if err != nil {
 		return "", err
 	}

--- a/src/database-backup-restore/config/temp_folder_manager_test.go
+++ b/src/database-backup-restore/config/temp_folder_manager_test.go
@@ -3,8 +3,6 @@ package config_test
 import (
 	. "database-backup-restore/config"
 
-	"io/ioutil"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -29,7 +27,7 @@ var _ = Describe("TempFolderManager", func() {
 			filePath, err := tempFolderManager.WriteTempFile("test contents")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(filePath).To(BeAnExistingFile())
-			Expect(ioutil.ReadFile(filePath)).To(Equal([]byte("test contents")))
+			Expect(os.ReadFile(filePath)).To(Equal([]byte("test contents")))
 		})
 	})
 
@@ -38,7 +36,7 @@ var _ = Describe("TempFolderManager", func() {
 			filePath, err := tempFolderManager.WriteTempFile("test contents")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(filePath).To(BeAnExistingFile())
-			Expect(ioutil.ReadFile(filePath)).To(Equal([]byte("test contents")))
+			Expect(os.ReadFile(filePath)).To(Equal([]byte("test contents")))
 
 			tempFolderManager.Cleanup()
 			Expect(filePath).NotTo(BeAnExistingFile())

--- a/src/database-backup-restore/integration_tests/database_backup_restore_test.go
+++ b/src/database-backup-restore/integration_tests/database_backup_restore_test.go
@@ -18,7 +18,6 @@ package integration_tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -185,14 +184,14 @@ var _ = Describe("Backup and Restore DB Utility", func() {
 })
 
 func tempFilePath() string {
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	Expect(err).NotTo(HaveOccurred())
 	tmpfile.Close()
 	return tmpfile.Name()
 }
 
 func invalidConfig() (string, error) {
-	invalidJsonConfig, err := ioutil.TempFile(os.TempDir(), "")
+	invalidJsonConfig, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return "", err
 	}
@@ -201,7 +200,7 @@ func invalidConfig() (string, error) {
 }
 
 func invalidAdapterConfig() (string, error) {
-	invalidAdapterConfig, err := ioutil.TempFile(os.TempDir(), "")
+	invalidAdapterConfig, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return "", err
 	}
@@ -210,7 +209,7 @@ func invalidAdapterConfig() (string, error) {
 }
 
 func emptyTablesConfig() (string, error) {
-	validConfig, err := ioutil.TempFile(os.TempDir(), "")
+	validConfig, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return "", err
 	}
@@ -231,7 +230,7 @@ func emptyTablesConfig() (string, error) {
 }
 
 func tlsBlockWithoutCaConfig() (string, error) {
-	validConfig, err := ioutil.TempFile(os.TempDir(), "")
+	validConfig, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return "", err
 	}
@@ -252,7 +251,7 @@ func tlsBlockWithoutCaConfig() (string, error) {
 }
 
 func missingClientKeyConfig() (string, error) {
-	validConfig, err := ioutil.TempFile(os.TempDir(), "")
+	validConfig, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return "", err
 	}
@@ -278,7 +277,7 @@ func missingClientKeyConfig() (string, error) {
 }
 
 func missingClientCertConfig() (string, error) {
-	validConfig, err := ioutil.TempFile(os.TempDir(), "")
+	validConfig, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return "", err
 	}
@@ -304,7 +303,7 @@ func missingClientCertConfig() (string, error) {
 }
 
 func validPgConfig() (string, error) {
-	validConfig, err := ioutil.TempFile(os.TempDir(), "")
+	validConfig, err := os.CreateTemp(os.TempDir(), "")
 	if err != nil {
 		return "", err
 	}
@@ -324,10 +323,10 @@ func validPgConfig() (string, error) {
 }
 
 func saveFile(content string) *os.File {
-	configFile, err := ioutil.TempFile(os.TempDir(), time.Now().String())
+	configFile, err := os.CreateTemp(os.TempDir(), time.Now().String())
 	Expect(err).NotTo(HaveOccurred())
 
-	ioutil.WriteFile(configFile.Name(), []byte(content), 0755)
+	os.WriteFile(configFile.Name(), []byte(content), 0755)
 
 	return configFile
 }

--- a/src/database-backup-restore/integration_tests/mysql_test.go
+++ b/src/database-backup-restore/integration_tests/mysql_test.go
@@ -18,7 +18,6 @@ package integration_tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -406,7 +405,7 @@ var _ = Describe("MySQL", func() {
 			})
 
 			JustBeforeEach(func() {
-				err := ioutil.WriteFile(artifactFile, []byte("SOME BACKUP SQL"), 0644)
+				err := os.WriteFile(artifactFile, []byte("SOME BACKUP SQL"), 0644)
 				if err != nil {
 					log.Fatalf("Failed to write to artifact file, %s\n", err.Error())
 				}
@@ -981,7 +980,7 @@ var _ = Describe("MySQL", func() {
 			})
 
 			JustBeforeEach(func() {
-				err := ioutil.WriteFile(artifactFile, []byte("SOME BACKUP SQL"), 0644)
+				err := os.WriteFile(artifactFile, []byte("SOME BACKUP SQL"), 0644)
 				if err != nil {
 					log.Fatalf("Failed to write to artifact file, %s\n", err.Error())
 				}
@@ -1556,7 +1555,7 @@ var _ = Describe("MySQL", func() {
 			})
 
 			JustBeforeEach(func() {
-				err := ioutil.WriteFile(artifactFile, []byte("SOME BACKUP SQL"), 0644)
+				err := os.WriteFile(artifactFile, []byte("SOME BACKUP SQL"), 0644)
 				if err != nil {
 					log.Fatalf("Failed to write to artifact file, %s\n", err.Error())
 				}

--- a/src/database-backup-restore/postgres/restorer.go
+++ b/src/database-backup-restore/postgres/restorer.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"io/ioutil"
-
 	"database-backup-restore/config"
 	"database-backup-restore/runner"
 )
@@ -31,7 +29,7 @@ func (r Restorer) Action(artifactFilePath string) error {
 		return err
 	}
 
-	listFile, err := ioutil.TempFile("", "backup-restore-sdk")
+	listFile, err := os.CreateTemp("", "backup-restore-sdk")
 	if err != nil {
 		return err
 	}

--- a/src/database-backup-restore/system_tests/postgresql_mutual_tls/postgresql_mutual_tls_test.go
+++ b/src/database-backup-restore/system_tests/postgresql_mutual_tls/postgresql_mutual_tls_test.go
@@ -2,7 +2,6 @@ package postgresql_mutual_tls_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -290,9 +289,9 @@ var _ = Describe("postgres with mutual tls", func() {
 })
 
 func writeToFile(contents string) string {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	Expect(err).NotTo(HaveOccurred())
 	path := file.Name()
-	Expect(ioutil.WriteFile(path, []byte(contents), 0777)).To(Succeed())
+	Expect(os.WriteFile(path, []byte(contents), 0777)).To(Succeed())
 	return path
 }

--- a/src/gcs-blobstore-backup-restore/artifact.go
+++ b/src/gcs-blobstore-backup-restore/artifact.go
@@ -3,7 +3,6 @@ package gcs
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 //go:generate counterfeiter -o fakes/fake_artifact.go . BackupArtifact
@@ -34,11 +33,11 @@ func (a Artifact) Write(backups map[string]BucketBackup) error {
 		return err
 	}
 
-	return ioutil.WriteFile(a.path, filesContents, 0644)
+	return os.WriteFile(a.path, filesContents, 0644)
 }
 
 func (a Artifact) Read() (map[string]BucketBackup, error) {
-	fileContents, err := ioutil.ReadFile(a.path)
+	fileContents, err := os.ReadFile(a.path)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read artifact file %s: %s", a.path, err.Error())
 	}

--- a/src/gcs-blobstore-backup-restore/artifact_test.go
+++ b/src/gcs-blobstore-backup-restore/artifact_test.go
@@ -2,7 +2,6 @@ package gcs_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"gcs-blobstore-backup-restore"
@@ -18,7 +17,7 @@ var _ = Describe("Artifact", func() {
 		Context("when the artifact file is writable", func() {
 			BeforeEach(func() {
 				var err error
-				artifactFile, err = ioutil.TempFile("", "gcs_backup")
+				artifactFile, err = os.CreateTemp("", "gcs_backup")
 				Expect(err).NotTo(HaveOccurred())
 
 				artifact = gcs.NewArtifact(artifactFile.Name())
@@ -37,7 +36,7 @@ var _ = Describe("Artifact", func() {
 				)
 
 				Expect(err).NotTo(HaveOccurred())
-				fileContent, err := ioutil.ReadFile(artifactFile.Name())
+				fileContent, err := os.ReadFile(artifactFile.Name())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fileContent).To(MatchJSON(`{
 					"bucket_identifier": {
@@ -70,7 +69,7 @@ var _ = Describe("Artifact", func() {
 		Context("when the artifact file exists", func() {
 			Context("and is valid json", func() {
 				It("returns the artifact contents", func() {
-					artifactFile, err := ioutil.TempFile("", "gcs_backup")
+					artifactFile, err := os.CreateTemp("", "gcs_backup")
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = artifactFile.Write([]byte(`{
@@ -103,7 +102,7 @@ var _ = Describe("Artifact", func() {
 
 			Context("and is not valid json", func() {
 				It("returns an error", func() {
-					artifactFile, err := ioutil.TempFile("", "gcs_backup")
+					artifactFile, err := os.CreateTemp("", "gcs_backup")
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = artifactFile.Write([]byte(`not-valid{json`))

--- a/src/gcs-blobstore-backup-restore/config.go
+++ b/src/gcs-blobstore-backup-restore/config.go
@@ -2,7 +2,7 @@ package gcs
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 type Config struct {
@@ -11,7 +11,7 @@ type Config struct {
 }
 
 func ParseConfig(configFilePath string) (map[string]Config, error) {
-	configContents, err := ioutil.ReadFile(configFilePath)
+	configContents, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func ParseConfig(configFilePath string) (map[string]Config, error) {
 }
 
 func ReadGCPServiceAccountKey(gcpConfigFilePath string) (string, error) {
-	gcpConfigContents, err := ioutil.ReadFile(gcpConfigFilePath)
+	gcpConfigContents, err := os.ReadFile(gcpConfigFilePath)
 	if err != nil {
 		return "", err
 	}

--- a/src/gcs-blobstore-backup-restore/config_test.go
+++ b/src/gcs-blobstore-backup-restore/config_test.go
@@ -1,8 +1,6 @@
 package gcs_test
 
 import (
-	"io/ioutil"
-
 	"os"
 
 	"gcs-blobstore-backup-restore"
@@ -18,7 +16,7 @@ var _ = Describe("Config", func() {
 			var config map[string]gcs.Config
 
 			BeforeEach(func() {
-				configFile, err = ioutil.TempFile("", "gcs_config")
+				configFile, err = os.CreateTemp("", "gcs_config")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -29,7 +27,7 @@ var _ = Describe("Config", func() {
 					"backup_bucket_name": "backup_bucket"
 				}
 			}`
-				ioutil.WriteFile(configFile.Name(), []byte(configJson), 0644)
+				os.WriteFile(configFile.Name(), []byte(configJson), 0644)
 
 				config, err = gcs.ParseConfig(configFile.Name())
 
@@ -50,9 +48,9 @@ var _ = Describe("Config", func() {
 
 		Context("when the config file is not valid", func() {
 			It("returns an error", func() {
-				configFile, err := ioutil.TempFile("", "gcs_config")
+				configFile, err := os.CreateTemp("", "gcs_config")
 				Expect(err).NotTo(HaveOccurred())
-				ioutil.WriteFile(configFile.Name(), []byte{}, 0000)
+				os.WriteFile(configFile.Name(), []byte{}, 0000)
 
 				_, err = gcs.ParseConfig(configFile.Name())
 
@@ -68,13 +66,13 @@ var _ = Describe("Config", func() {
 			var config string
 
 			BeforeEach(func() {
-				configFile, err = ioutil.TempFile("", "gcs_config")
+				configFile, err = os.CreateTemp("", "gcs_config")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("reads", func() {
 				configJson := `{"name":"value"}`
-				ioutil.WriteFile(configFile.Name(), []byte(configJson), 0644)
+				os.WriteFile(configFile.Name(), []byte(configJson), 0644)
 
 				config, err = gcs.ReadGCPServiceAccountKey(configFile.Name())
 

--- a/src/gcs-blobstore-backup-restore/contract_test/gcs_helpers_test.go
+++ b/src/gcs-blobstore-backup-restore/contract_test/gcs_helpers_test.go
@@ -9,8 +9,6 @@ import (
 
 	"fmt"
 
-	"io/ioutil"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -23,9 +21,9 @@ func MustHaveEnv(keyname string) string {
 }
 
 func Authenticate(serviceAccountKey, projectName string) {
-	tmpFile, err := ioutil.TempFile("", "gcp_service_account_key_")
+	tmpFile, err := os.CreateTemp("", "gcp_service_account_key_")
 	Expect(err).NotTo(HaveOccurred())
-	err = ioutil.WriteFile(tmpFile.Name(), []byte(serviceAccountKey), 0644)
+	err = os.WriteFile(tmpFile.Name(), []byte(serviceAccountKey), 0644)
 	Expect(err).NotTo(HaveOccurred())
 	runSuccessfully("gcloud", "auth", "activate-service-account", "--key-file", tmpFile.Name(), "--project", projectName)
 }
@@ -51,11 +49,11 @@ func UploadFileWithDir(bucketName, dir, blobName, fileContents string) {
 }
 
 func createTmpFile(dirName, fileName, fileContents string) *os.File {
-	dir, err := ioutil.TempDir("", dirName)
+	dir, err := os.MkdirTemp("", dirName)
 	Expect(err).NotTo(HaveOccurred())
-	file, err := ioutil.TempFile(dir, fileName)
+	file, err := os.CreateTemp(dir, fileName)
 	Expect(err).NotTo(HaveOccurred())
-	err = ioutil.WriteFile(file.Name(), []byte(fileContents), 0644)
+	err = os.WriteFile(file.Name(), []byte(fileContents), 0644)
 	Expect(err).NotTo(HaveOccurred())
 	return file
 }

--- a/src/s3-blobstore-backup-restore/cmd/s3-blobstore-backup-restore/main.go
+++ b/src/s3-blobstore-backup-restore/cmd/s3-blobstore-backup-restore/main.go
@@ -7,8 +7,6 @@ import (
 	"s3-blobstore-backup-restore/unversioned"
 
 	"encoding/json"
-	"io/ioutil"
-
 	"errors"
 	"flag"
 
@@ -47,7 +45,7 @@ func main() {
 		exitWithError("Failed to parse flags", err)
 	}
 
-	rawConfig, err := ioutil.ReadFile(flags.ConfigPath)
+	rawConfig, err := os.ReadFile(flags.ConfigPath)
 	if err != nil {
 		exitWithError("Failed to read config", err)
 	}

--- a/src/s3-blobstore-backup-restore/incremental/artifact.go
+++ b/src/s3-blobstore-backup-restore/incremental/artifact.go
@@ -3,7 +3,6 @@ package incremental
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 //go:generate counterfeiter -o fakes/fake_artifact.go . Artifact
@@ -37,7 +36,7 @@ func (a artifact) Write(backups map[string]Backup) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(a.path, filesContents, 0644)
+	err = os.WriteFile(a.path, filesContents, 0644)
 	if err != nil {
 		return fmt.Errorf("could not write backup file: %s", err.Error())
 	}
@@ -46,7 +45,7 @@ func (a artifact) Write(backups map[string]Backup) error {
 }
 
 func (a artifact) Load() (map[string]Backup, error) {
-	bytes, err := ioutil.ReadFile(a.path)
+	bytes, err := os.ReadFile(a.path)
 	if err != nil {
 		return nil, fmt.Errorf("could not read backup file: %s", err.Error())
 	}

--- a/src/s3-blobstore-backup-restore/incremental/artifact_test.go
+++ b/src/s3-blobstore-backup-restore/incremental/artifact_test.go
@@ -1,7 +1,6 @@
 package incremental_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -16,7 +15,7 @@ var _ = Describe("Artifact", func() {
 
 	BeforeEach(func() {
 		var err error
-		artifactFile, err = ioutil.TempFile("", "s3_backup")
+		artifactFile, err = os.CreateTemp("", "s3_backup")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -35,7 +34,7 @@ var _ = Describe("Artifact", func() {
 			}
 		}`
 
-			err := ioutil.WriteFile(artifactFile.Name(), []byte(body), 644)
+			err := os.WriteFile(artifactFile.Name(), []byte(body), 644)
 			Expect(err).NotTo(HaveOccurred())
 
 			artifact := incremental.NewArtifact(artifactFile.Name())
@@ -67,7 +66,7 @@ var _ = Describe("Artifact", func() {
 
 	Context("when the back artifact file is not valid json", func() {
 		It("errors", func() {
-			err := ioutil.WriteFile(artifactFile.Name(), []byte("not-valid-json"), 644)
+			err := os.WriteFile(artifactFile.Name(), []byte("not-valid-json"), 644)
 			Expect(err).NotTo(HaveOccurred())
 
 			artifact := incremental.NewArtifact(artifactFile.Name())
@@ -97,7 +96,7 @@ var _ = Describe("Artifact", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 
-		fileContent, err := ioutil.ReadFile(artifactFile.Name())
+		fileContent, err := os.ReadFile(artifactFile.Name())
 		Expect(fileContent).To(MatchJSON(`{
 			"bucket_id": {
 				"bucket_name": "backup-bucket",
@@ -130,7 +129,7 @@ var _ = Describe("Artifact", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 
-			fileContent, err := ioutil.ReadFile(artifactFile.Name())
+			fileContent, err := os.ReadFile(artifactFile.Name())
 			Expect(fileContent).To(MatchJSON(`{
 			"bucket_id": {
 				"src_backup_directory_path": "2000_01_02_03_04_05/bucket_id",
@@ -169,7 +168,7 @@ var _ = Describe("Artifact", func() {
 	Context("when the artifact has an invalid format", func() {
 		BeforeEach(func() {
 			artifact = incremental.NewArtifact(artifactFile.Name())
-			err := ioutil.WriteFile(artifactFile.Name(), []byte("THIS IS NOT VALID JSON"), 0666)
+			err := os.WriteFile(artifactFile.Name(), []byte("THIS IS NOT VALID JSON"), 0666)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/src/s3-blobstore-backup-restore/s3bucket/bucket_helpers_test.go
+++ b/src/s3-blobstore-backup-restore/s3bucket/bucket_helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"strings"
 	"time"
@@ -73,7 +72,7 @@ func getFileContents(bucket, endpoint, key string, creds s3bucket.AccessKey) str
 }
 
 func uploadFile(bucket, endpoint, key, body string, creds s3bucket.AccessKey) string {
-	bodyFile, _ := ioutil.TempFile("", "")
+	bodyFile, _ := os.CreateTemp("", "")
 	bodyFile.WriteString(body)
 	bodyFile.Close()
 
@@ -93,7 +92,7 @@ func uploadFile(bucket, endpoint, key, body string, creds s3bucket.AccessKey) st
 }
 
 func downloadFileToTmp(bucket, endpoint, key string, creds s3bucket.AccessKey) string {
-	bodyFile, _ := ioutil.TempFile("", "")
+	bodyFile, _ := os.CreateTemp("", "")
 	bodyFile.Close()
 
 	baseCmd := constructBaseCmd(endpoint)

--- a/src/s3-blobstore-backup-restore/versioned/artifact.go
+++ b/src/s3-blobstore-backup-restore/versioned/artifact.go
@@ -3,7 +3,6 @@ package versioned
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 //go:generate counterfeiter -o fakes/fake_artifact.go . Artifact
@@ -37,7 +36,7 @@ func (a FileArtifact) Save(backup map[string]BucketSnapshot) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(a.filePath, marshalledBackup, 0666)
+	err = os.WriteFile(a.filePath, marshalledBackup, 0666)
 	if err != nil {
 		return fmt.Errorf("could not write backup file: %s", err.Error())
 	}
@@ -46,7 +45,7 @@ func (a FileArtifact) Save(backup map[string]BucketSnapshot) error {
 }
 
 func (a FileArtifact) Load() (map[string]BucketSnapshot, error) {
-	bytes, err := ioutil.ReadFile(a.filePath)
+	bytes, err := os.ReadFile(a.filePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read backup file: %s", err.Error())
 	}

--- a/src/s3-blobstore-backup-restore/versioned/artifact_test.go
+++ b/src/s3-blobstore-backup-restore/versioned/artifact_test.go
@@ -3,13 +3,11 @@ package versioned_test
 import (
 	"os"
 
-	"io/ioutil"
-
 	"path/filepath"
 
-	"s3-blobstore-backup-restore/versioned"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"s3-blobstore-backup-restore/versioned"
 )
 
 var _ = Describe("FileArtifact", func() {
@@ -18,7 +16,7 @@ var _ = Describe("FileArtifact", func() {
 	var fileArtifact versioned.FileArtifact
 
 	BeforeEach(func() {
-		backupDir, _ = ioutil.TempDir("", "bbr_test_")
+		backupDir, _ = os.MkdirTemp("", "bbr_test_")
 		artifactPath = filepath.Join(backupDir, "blobstore.json")
 		fileArtifact = versioned.NewFileArtifact(artifactPath)
 	})
@@ -86,7 +84,7 @@ var _ = Describe("FileArtifact", func() {
 
 	Context("when the artifact has an invalid format", func() {
 		BeforeEach(func() {
-			ioutil.WriteFile(artifactPath, []byte("THIS IS NOT VALID JSON"), 0666)
+			os.WriteFile(artifactPath, []byte("THIS IS NOT VALID JSON"), 0666)
 		})
 
 		It("returns an error", func() {

--- a/src/system-tests/azure/azure_blobstore_system_test.go
+++ b/src/system-tests/azure/azure_blobstore_system_test.go
@@ -1,8 +1,6 @@
 package azure_test
 
 import (
-	"io/ioutil"
-
 	"os"
 	"strconv"
 	"time"
@@ -38,7 +36,7 @@ var _ = Describe("Azure backup and restore", func() {
 		fileName3 = "test_file_3_" + strconv.FormatInt(time.Now().Unix(), 10)
 
 		var err error
-		localArtifactDirectory, err = ioutil.TempDir("", "azure-blobstore-")
+		localArtifactDirectory, err = os.MkdirTemp("", "azure-blobstore-")
 		Expect(err).NotTo(HaveOccurred())
 
 		instanceArtifactDirPath = "/tmp/azure-blobstore-backup-restorer" + strconv.FormatInt(time.Now().Unix(), 10)

--- a/src/system-tests/azure/azure_client.go
+++ b/src/system-tests/azure/azure_client.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os/exec"
 
 	"encoding/json"
@@ -50,7 +49,7 @@ func (c AzureClient) DeleteFileInContainer(container, blobName string) {
 }
 
 func (c AzureClient) WriteFileInContainer(container, blobName, body string) string {
-	bodyFile, _ := ioutil.TempFile("", "write_file_in_container_")
+	bodyFile, _ := os.CreateTemp("", "write_file_in_container_")
 	bodyFile.WriteString(body)
 	bodyFile.Close()
 
@@ -87,7 +86,7 @@ func (c AzureClient) CreateContainer(name string) {
 }
 
 func (c AzureClient) ReadFileFromContainer(container, blobName string) string {
-	bodyFile, err := ioutil.TempFile("", "read_file_from_container_")
+	bodyFile, err := os.CreateTemp("", "read_file_from_container_")
 	if err != nil {
 		panic(err)
 	}
@@ -100,7 +99,7 @@ func (c AzureClient) ReadFileFromContainer(container, blobName string) string {
 		"--name", blobName,
 		"--file", bodyFile.Name())
 
-	body, err := ioutil.ReadFile(bodyFile.Name())
+	body, err := os.ReadFile(bodyFile.Name())
 	if err != nil {
 		panic(err)
 	}
@@ -112,7 +111,7 @@ func (c AzureClient) runAzureCommandSuccessfully(args ...string) *bytes.Buffer {
 	outputBuffer := new(bytes.Buffer)
 	errorBuffer := new(bytes.Buffer)
 
-	azureConfigDir, err := ioutil.TempDir("", "azure_")
+	azureConfigDir, err := os.MkdirTemp("", "azure_")
 	if err != nil {
 		panic(err)
 	}

--- a/src/system-tests/gcs/gcs_client_test.go
+++ b/src/system-tests/gcs/gcs_client_test.go
@@ -1,7 +1,6 @@
 package gcs_test
 
 import (
-	"io/ioutil"
 	"strconv"
 	"time"
 
@@ -15,7 +14,7 @@ import (
 type GCSClient struct{}
 
 func (c GCSClient) WriteBlobToBucket(bucket, blobName, body string) {
-	file, err := ioutil.TempFile("", "bbr-sdk-gcs-system-tests")
+	file, err := os.CreateTemp("", "bbr-sdk-gcs-system-tests")
 	Expect(err).NotTo(HaveOccurred())
 
 	_, err = file.WriteString(body)
@@ -25,11 +24,11 @@ func (c GCSClient) WriteBlobToBucket(bucket, blobName, body string) {
 }
 
 func (c GCSClient) WriteNBlobsToBucket(bucket string, blobName string, blobBody string, n int) {
-	blobsDir, err := ioutil.TempDir("", "testdir")
+	blobsDir, err := os.MkdirTemp("", "testdir")
 	Expect(err).NotTo(HaveOccurred())
 	for i := 0; i < n; i++ {
 		timestampedName := blobName + strconv.FormatInt(time.Now().Unix(), 10)
-		file, err := ioutil.TempFile(blobsDir, fmt.Sprintf(timestampedName, i))
+		file, err := os.CreateTemp(blobsDir, fmt.Sprintf(timestampedName, i))
 		Expect(err).NotTo(HaveOccurred())
 		_, err = file.WriteString(fmt.Sprintf(blobBody, i))
 		Expect(err).NotTo(HaveOccurred())
@@ -39,12 +38,12 @@ func (c GCSClient) WriteNBlobsToBucket(bucket string, blobName string, blobBody 
 }
 
 func (c GCSClient) ReadBlobFromBucket(bucket, blobName string) string {
-	file, err := ioutil.TempFile("", "bbr-sdk-gcs-system-tests")
+	file, err := os.CreateTemp("", "bbr-sdk-gcs-system-tests")
 	Expect(err).NotTo(HaveOccurred())
 
 	MustRunSuccessfully("gsutil", "cp", fmt.Sprintf("gs://%s/%s", bucket, blobName), file.Name())
 
-	body, err := ioutil.ReadFile(file.Name())
+	body, err := os.ReadFile(file.Name())
 	Expect(err).NotTo(HaveOccurred())
 
 	return string(body)
@@ -65,7 +64,7 @@ func (c GCSClient) ListDirsFromBucket(bucket string) string {
 	return string(session.Out.Contents())
 }
 func (c GCSClient) WriteNSizeBlobToBucket(bucket string, blobName string, size int) {
-	blobsDir, err := ioutil.TempDir("", "testdir")
+	blobsDir, err := os.MkdirTemp("", "testdir")
 	Expect(err).NotTo(HaveOccurred())
 	fileToCopy := fmt.Sprintf("%s/%s", blobsDir, blobName)
 	gigabyte := 1024 * 1024 * 1024

--- a/src/system-tests/s3/s3_helper_test.go
+++ b/src/system-tests/s3/s3_helper_test.go
@@ -24,8 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"io/ioutil"
-
 	. "github.com/onsi/gomega"
 )
 
@@ -101,7 +99,7 @@ func runAwsCommandOnBucketSuccessfully(args ...string) *bytes.Buffer {
 }
 
 func WriteFileInBucket(region, bucket, key, body string) {
-	bodyFile, _ := ioutil.TempFile("", "")
+	bodyFile, _ := os.CreateTemp("", "")
 	bodyFile.WriteString(body)
 	bodyFile.Close()
 

--- a/src/system-tests/s3/s3_unversioned_blobstore_system_test.go
+++ b/src/system-tests/s3/s3_unversioned_blobstore_system_test.go
@@ -25,8 +25,6 @@ import (
 
 	"strconv"
 
-	"io/ioutil"
-
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -49,7 +47,7 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 	Context("when bpm is not enabled", func() {
 		BeforeEach(func() {
 			var err error
-			localArtifact, err = ioutil.TempFile("", "blobstore-")
+			localArtifact, err = os.CreateTemp("", "blobstore-")
 			Expect(err).NotTo(HaveOccurred())
 
 			liveRegion = MustHaveEnv("S3_UNVERSIONED_BUCKET_REGION")
@@ -122,7 +120,7 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 
 				Expect(session).Should(Exit(0))
 
-				fileContents, err := ioutil.ReadFile(localArtifact.Name())
+				fileContents, err := os.ReadFile(localArtifact.Name())
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fileContents).To(ContainSubstring("\"my_bucket\":{"))
@@ -195,7 +193,7 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 
 					Expect(session).Should(Exit(0))
 
-					fileContents, err := ioutil.ReadFile(localArtifact.Name())
+					fileContents, err := os.ReadFile(localArtifact.Name())
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fileContents).To(ContainSubstring("\"my_bucket\":{"))
@@ -230,7 +228,7 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 	Context("when bpm is enabled", func() {
 		BeforeEach(func() {
 			var err error
-			localArtifact, err = ioutil.TempFile("", "blobstore-")
+			localArtifact, err = os.CreateTemp("", "blobstore-")
 			Expect(err).NotTo(HaveOccurred())
 
 			liveRegion = MustHaveEnv("S3_UNVERSIONED_BPM_BUCKET_REGION")
@@ -291,7 +289,7 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 	Context("when the same bucket is used for two bucket IDs", func() {
 		BeforeEach(func() {
 			var err error
-			localArtifact, err = ioutil.TempFile("", "blobstore-")
+			localArtifact, err = os.CreateTemp("", "blobstore-")
 			Expect(err).NotTo(HaveOccurred())
 
 			liveRegion = MustHaveEnv("S3_UNVERSIONED_BUCKET_REGION")
@@ -344,7 +342,7 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 					instanceArtifactDirPath+"/blobstore.json", localArtifact.Name())
 				Expect(session).Should(Exit(0))
 
-				fileContents, err := ioutil.ReadFile(localArtifact.Name())
+				fileContents, err := os.ReadFile(localArtifact.Name())
 				Expect(err).NotTo(HaveOccurred())
 
 				var backups map[string]incremental.Backup
@@ -353,9 +351,9 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 
 				Expect(backups).To(Equal(map[string]incremental.Backup{
 					"bucket1": {
-						BucketName:   backupBucket,
-						BucketRegion: backupRegion,
-						Blobs:        backups["bucket1"].Blobs, //skip
+						BucketName:             backupBucket,
+						BucketRegion:           backupRegion,
+						Blobs:                  backups["bucket1"].Blobs,                  //skip
 						SrcBackupDirectoryPath: backups["bucket1"].SrcBackupDirectoryPath, //skip
 					},
 					"bucket2": {
@@ -389,7 +387,7 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 	Context("when there are a larger number of files", func() {
 		BeforeEach(func() {
 			var err error
-			localArtifact, err = ioutil.TempFile("", "blobstore-")
+			localArtifact, err = os.CreateTemp("", "blobstore-")
 			Expect(err).NotTo(HaveOccurred())
 
 			liveRegion = MustHaveEnv("S3_UNVERSIONED_LARGE_NUMBER_OF_FILES_BUCKET_REGION")
@@ -445,7 +443,7 @@ var _ = Describe("S3 unversioned backup and restore", func() {
 
 		BeforeEach(func() {
 			var err error
-			localArtifact, err = ioutil.TempFile("", "blobstore-")
+			localArtifact, err = os.CreateTemp("", "blobstore-")
 			Expect(err).NotTo(HaveOccurred())
 
 			liveRegion = MustHaveEnv("S3_UNVERSIONED_BUCKET_REGION")


### PR DESCRIPTION
The Go ioutil package is deprecated. While it still works, the risk of leaving it in the code is that folks start to copy an anti-pattern. This commit removes all the usages of ioutil.