### PR TITLE
Modify postgres-15 blob to include MINOR semver in path

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -50,7 +50,7 @@ postgres/postgresql-13.9.tar.gz:
   size: 28087413
   object_id: 16b8c629-8d37-4b78-73f1-d6c63df2ff50
   sha: sha256:edac4c7df35e62331dd7067665d4149536be092a313bb1fe950780967a9e57dd
-postgres/postgresql-15.tar.gz:
+postgres/postgresql-15.1.tar.gz:
   size: 29778341
   object_id: 1d10fd47-0364-4e8f-7845-6bfcc52a95b2
   sha: sha256:ea2cf059a85882654b989acd07edc121833164a30340faee0d3615cf7058e66c

--- a/packages/database-backup-restorer-postgres-15/packaging
+++ b/packages/database-backup-restorer-postgres-15/packaging
@@ -1,6 +1,6 @@
 set -e
 
-POSTGRES_VERSION=15
+POSTGRES_VERSION=15.1
 
 mkdir -p postgresql-${POSTGRES_VERSION}
 

--- a/packages/database-backup-restorer-postgres-15/spec
+++ b/packages/database-backup-restorer-postgres-15/spec
@@ -4,4 +4,4 @@ name: database-backup-restorer-postgres-15
 dependencies: []
 
 files:
-- postgres/postgresql-15.tar.gz
+- postgres/postgresql-15.1.tar.gz


### PR DESCRIPTION
[#183954580]

Without this, existing automation to automatically bump things
was interpreting that postgres-15 was older than postgres-15.1
and was creating a PR.
