### PR TITLE
fix: postgres 15 mutual-tls test

### DIFF
--- a/ci/dockerfiles/run-system-db-tests/postgres/enable_tls.sh
+++ b/ci/dockerfiles/run-system-db-tests/postgres/enable_tls.sh
@@ -50,7 +50,7 @@ hostssl all  all  0.0.0.0/0  md5
 EOF
   elif [[ "${ENABLE_TLS}" == "mutual" ]]; then
 
-      if postgres --version | grep -o "15.1"; then
+      if postgres --version | grep -E -o "15.[0-9]+"; then
 cat << 'EOF' > /var/lib/postgresql/data/pg_hba.conf
 hostssl all  all  0.0.0.0/0  md5 clientcert=verify-full
 EOF


### PR DESCRIPTION
- ~~I had a look to [the Makefile definition for postgres tests](https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/a4a7b8b88fc8843a5fa0a88353d75a0ad869ed73/Makefile#L163). In the definition we can see that we run the same tests with different values for the ENABLE_TLS environment variable. The last one being `ENABLE_TLS="mutual"`~~

- ~~Knowing that these environment variables [can be used inside our actual test code](https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/main/src/database-backup-restore/scripts/run-system-db-tests-postgres.bash) but it also is available [at container creation time (because it is passed in the docker-compose file)](https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/a4a7b8b88fc8843a5fa0a88353d75a0ad869ed73/docker-compose.yml#LL115C7-L115C17), I then thought it must be something related to the container creation since [GHAction error complains about a container being unhealthy even before the tests started to run](https://github.com/cloudfoundry/backup-and-restore-sdk-release/actions/runs/4168989518/jobs/7216480736#step:5:1444).~~
- ~~I decided to have a look at [the container definition for Postgres](https://github.com/cloudfoundry/backup-and-restore-sdk-release/tree/main/ci/dockerfiles/run-system-db-tests/postgres) and determined that [the problem should be related to this line where we check “${ENABLE_TLS}” == “mutual”](https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/a4a7b8b88fc8843a5fa0a88353d75a0ad869ed73/ci/dockerfiles/run-system-db-tests/postgres/enable_tls.sh#L51).~~
- ~~I saw that inside that condition [there is another one which says if postgres --version | grep -o "15.1";](https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/a4a7b8b88fc8843a5fa0a88353d75a0ad869ed73/ci/dockerfiles/run-system-db-tests/postgres/enable_tls.sh#L53)~~
- ~~I then remembered that [we are passing postgres version dynamically in the Makefile (to test against different versions of Postgres)](https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/main/Makefile#L49-L60). According to the previous bullet we are greping to find “15.1” but our Makefile mentions 15-bullseye (a non-fixed image version).~~
- ~~I checked [Postgres' Dockerhub page](https://hub.docker.com/_/postgres) and found that 15-bullseye is now equivalent to 15.2, so the condition we saw in a previous bullet `grep -o "15.1"` was now failing and entering the else branch.~~