### PR TITLE
Stop testing deprecated Xenial Stemcell

### DIFF
--- a/.github/workflows/run-test-pyramid.yml
+++ b/.github/workflows/run-test-pyramid.yml
@@ -38,15 +38,3 @@ jobs:
       run: FOCUS=ubuntu-bionic make docker-system-mysql
     - name: "Stemcell: Bionic | Postgres: Multiple"
       run: FOCUS=ubuntu-bionic make docker-system-postgres
-
-  run-system-tests-xenial:
-    needs: run-unit-tests
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: "Stemcell: Xenial | MariaDB: Multiple"
-      run: FOCUS=ubuntu-xenial make docker-system-mariadb
-    - name: "Stemcell: Xenial | MySQL: Multiple"
-      run: FOCUS=ubuntu-xenial make docker-system-mysql
-    - name: "Stemcell: Xenial | Postgres: Multiple"
-      run: FOCUS=ubuntu-xenial make docker-system-postgres

--- a/Makefile
+++ b/Makefile
@@ -18,46 +18,34 @@ bump-postgres: config/private.yml ## update blobs, spec and packaging to Postgre
 supported-stemcells=\
   ubuntu-bionic \
   ubuntu-jammy  \
-  ubuntu-xenial \
 
 supported-mariadb=\
   ubuntu-bionic~~~10.9-jammy  \
   ubuntu-jammy~~~~10.9-jammy  \
-  ubuntu-xenial~~~10.9-jammy  \
   ubuntu-bionic~~~10.7-focal  \
   ubuntu-jammy~~~~10.7-focal  \
-  ubuntu-xenial~~~10.7-focal  \
   ubuntu-bionic~~~10.5-focal  \
   ubuntu-jammy~~~~10.5-focal  \
-  ubuntu-xenial~~~10.5-focal  \
   ubuntu-bionic~~~10.2-bionic \
   ubuntu-jammy~~~~10.2-bionic \
-  ubuntu-xenial~~~10.2-bionic \
 
 supported-mysql=\
   ubuntu-bionic~~~8.0-debian  \
   ubuntu-jammy~~~~8.0-debian  \
-  ubuntu-xenial~~~8.0-debian  \
   ubuntu-bionic~~~8.0-oracle  \
   ubuntu-jammy~~~~8.0-oracle  \
-  ubuntu-xenial~~~8.0-oracle  \
   ubuntu-bionic~~~5.7-debian  \
   ubuntu-jammy~~~~5.7-debian  \
-  ubuntu-xenial~~~5.7-debian  \
 
 supported-postgres=\
   ubuntu-bionic~~~15-bullseye  \
   ubuntu-jammy~~~~15-bullseye  \
-  ubuntu-xenial~~~15-bullseye  \
   ubuntu-bionic~~~13-bullseye  \
   ubuntu-jammy~~~~13-bullseye  \
-  ubuntu-xenial~~~13-bullseye  \
   ubuntu-bionic~~~11-bullseye  \
   ubuntu-jammy~~~~11-bullseye  \
-  ubuntu-xenial~~~11-bullseye  \
   ubuntu-bionic~~~10-bullseye  \
   ubuntu-jammy~~~~10-bullseye  \
-  ubuntu-xenial~~~10-bullseye  \
 
 
 docker-clean: ## remove containers created to run the tests


### PR DESCRIPTION
I saw PR #934 was closed. That’s fine.
It was the simplest way to fix Xenial GHActions failures: https://github.com/cloudfoundry/backup-and-restore-sdk-release/actions/runs/4368457567

This PR removes Xenial tests instead. If preferred.