### PR TITLE
Fix GH Actions unit-tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,4 +27,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.0.1
+   2.4.11

--- a/ci/dockerfiles/sdk-template-unit-tests/Dockerfile
+++ b/ci/dockerfiles/sdk-template-unit-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:3.1.4
 
 ENTRYPOINT /backup-and-restore-sdk-release/scripts/run-template-tests.bash
 


### PR DESCRIPTION
Unit-Tests have been failing since the PR to Bump bosh-template from 2.3.0 to 2.4.0 was merged: https://github.com/cloudfoundry/backup-and-restore-sdk-release/pull/841

I have traced down the problem to following commit in bosh-template: https://github.com/cloudfoundry/bosh/commit/bfd9b01cfc03883cda9afa6bef9a36b2679240b5

The option `aliases: true` was causing issues in the Ruby version we were using to run the tests. I have updated the `FROM ruby` instruction accordingly in the Dockerfile.

Additionally, Ruby 3 removed several functions required by older versions of Bundler. To account for this I updated Bundler version too: https://stackoverflow.com/questions/73522137/search-up-undefined-method-untaint-error-after-ruby-upgrade

To decide which version of Ruby and Bundler we wanted to use I looked at ruby-buildpack from CF Community: https://github.com/cloudfoundry/ruby-buildpack/blob/master/CHANGELOG