### PR TITLE
Fix autobump mysql to detect latest version

### DIFF
--- a/scripts/autobump-mysql.sh
+++ b/scripts/autobump-mysql.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export VERSIONS_URL='https://downloads.mysql.com/archives/community/'
+export VERSIONS_URL='https://endoflife.date/mysql'
 
 HTML="$(curl -s -L "${VERSIONS_URL}")"
-VALUES="$(echo "${HTML}" | xmllint --html --xpath "//select[@id='version']/option[@value=text()]/@value" - 2>/dev/null)"
+VALUES="$(echo "${HTML}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 ALL_VERSIONS="$(echo "${VALUES}" | grep -Eo '[0-9]+(\.[0-9]+){1,2}[a-zA-Z]?')"
 
 export BLOBS_PREFIX="mysql"


### PR DESCRIPTION
Latest versions are not detected as soon as they are released. Latest versions aren't listed in https://downloads.mysql.com/archives/community/ anymore.

I believe they were in the past, but MySQL now uses that url as an "archive" for older releases.