### PR TITLE
Make CI use `bump-golang` for bumping golang

### DIFF
--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -107,11 +107,6 @@ resource_types:
     repository: pivotalservices/concourse-curl-resource
     tag: latest
 
-- name: cryogenics-essentials
-  type: registry-image
-  source:
-    repository: cryogenics/essentials
-
 - name: bosh-deployment
   type: docker-image
   source:
@@ -161,6 +156,11 @@ resource_types:
     repository: cftoolsmiths/toolsmiths-envs-resource
 
 resources:
+- name: cryogenics-essentials
+  type: registry-image
+  source:
+    repository: cryogenics/essentials
+
 - name: pxc-release
   type: bosh-io-release
   source:
@@ -1618,6 +1618,8 @@ jobs:
         file: cryogenics-essentials/tag
       - task: bump-tasks
         file: cryogenics-concourse-tasks/deps-automation/bump-concourse-tasks/task.yml
+        params:
+          TASKS_FOLDER: ci/tasks/
         input_mapping:
           repo: backup-and-restore-sdk-release-main
           image: cryogenics-essentials

--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -1398,8 +1398,8 @@ jobs:
     - get: backup-and-restore-sdk-release-main
       params:
         branch: main
-  - task: bosh-vendor-package
-    file: cryogenics-concourse-tasks/deps-automation/bosh-vendor-package/task.yml
+  - task: bump-golang
+    file: cryogenics-concourse-tasks/deps-automation/bump-golang/task.yml
     input_mapping:
       release: backup-and-restore-sdk-release-main
       vendored-package-release: golang-release


### PR DESCRIPTION
    
    I'm renaming the `bosh-vendor-package` task to `bump-golang`. It's only ever
    used to bump golang. It has golang-specific code in it.
    
    [#185166479](https://www.pivotaltracker.com/story/show/185166479)
