### PR TITLE
fix more issues with the autobumping script

### DIFF
--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -1582,11 +1582,13 @@ jobs:
   - in_parallel:
     - get: backup-and-restore-sdk-release-main
     - get: cryogenics-concourse-tasks
+    - get: image-backup-restore
     - get: daily-trigger
       trigger: true
 
   - task: bump-openssl-1
     file: cryogenics-concourse-tasks/deps-automation/bump-package/task.yml
+    image: image-backup-restore
     input_mapping:
       task-repo: cryogenics-concourse-tasks
       bump-repo: backup-and-restore-sdk-release-main


### PR DESCRIPTION
- remove copy paste leftover which referenced an undefined var
- override the image in ci. The cryogenics essentials image doesn't contain `xmllint`
- add callbacks to deal with the version of `openssl1.1.1[a-z]`, the default parsing will stop not properly deal with the letter contained in the version.