### PR TITLE
[CI] Allow ci to pick the latest cryo-essentials

### DIFF
--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -253,7 +253,6 @@ resources:
   type: registry-image
   source:
     repository: harbor-repo.vmware.com/cryogenics/essentials
-    tag: latest
 
 - name: image-backup-restore
   type: registry-image


### PR DESCRIPTION
During a recent migration from one CI to another, a `latest` tag was added to the cryogenics-essentials image.

This had the side effect of affecting the way our CI image bumper works. That bumper attempts to bump the image used in various pipeline tasks to whatever tag concourse reports from this image resource. If we force it to use the tag `latest`, then we will attempt to bump our tasks to `latest` instead of to whatever tag happens to be the most recent.

This wouldn't change our CI's behaviour very much, but it would take away our audit capabilities. If we allow concourse to pick our tags for us, then we get to record the exact tag used in our tasks at any given time.