### PR TITLE
readd mysql 5.7 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ supported-mariadb=\
   ubuntu-xenial~~~10.2-bionic \
 
 supported-mysql=\
+  ubuntu-bionic~~~5.7-debian  \
+  ubuntu-jammy~~~~5.7-debian  \
+  ubuntu-xenial~~~5.7-debian  \
   ubuntu-bionic~~~8.0-debian  \
   ubuntu-jammy~~~~8.0-debian  \
   ubuntu-xenial~~~8.0-debian  \

--- a/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
+++ b/ci/pipelines/backup-and-restore-sdk-release/pipeline.yml
@@ -98,6 +98,18 @@ mysql_certs_common: &mysql_certs_common
   databases.certificate: &mysql_cert ((cerberus:bbr/sdk-db-certs.mysql_client_cert))
   databases.private_key: &mysql_private_key ((cerberus:bbr/sdk-db-certs.mysql_client_key))
 
+
+mysql-5-7-deployment-name: &mysql-5-7-deployment-name mysql-5-7-dev
+mysql-5-7-host: &mysql-5-7-host 10.0.255.9
+
+mysql_params_5_7: &mysql_params_5_7
+  MYSQL_HOSTNAME: *mysql-5-7-host
+  MYSQL_CA_CERT: *mysql_ca_cert
+  MYSQL_CLIENT_CERT: *mysql_cert
+  MYSQL_CLIENT_KEY: *mysql_private_key
+  <<: *mysql_common
+
+
 mysql-8-0-deployment-name: &mysql-8-0-deployment-name mysql-8-0-dev
 mysql-8-0-host: &mysql-8-0-host 10.0.255.10
 
@@ -480,6 +492,12 @@ resources:
     deployment: *mysql-8-0-deployment-name
     skip_check: true
 
+- name: mysql-5-7-deployment
+  type: bosh-deployment
+  source:
+    deployment: *mysql-5-7-deployment-name
+    skip_check: true
+
 - name: postgres-11-dev-deployment
   type: bosh-deployment
   source:
@@ -859,8 +877,6 @@ jobs:
     input_mapping:
       cf-deployment-env: cf-deployment-env-airgapped
   - do:
-    #! Before 2024/01/15 there were two deployments done here. The comment is left in place
-    #! to avoid debugging a future issue if we ever need a 2nd mysql deployment again.
     #! It seems that 2 deployments cannot be performed in parallel if they
     #! compile the same release against the same stemcell and therefore BOSH
     #! refuses to grant some locks.
@@ -875,6 +891,26 @@ jobs:
           deployment-name: *mysql-8-0-deployment-name
           db_password: *mysql-password
           db_host: *mysql-8-0-host
+          availability_zone: z1
+          <<: *mysql_certs_common
+          vm_extensions: ["cf-tcp-router-network-properties"]
+        ops_files: 
+        - backup-and-restore-sdk-release/ci/manifests/ops-files/apply_vm_extension.yml
+        source_file: source-file/source-file.yml
+        releases:
+        - bpm-release/*.tgz
+        - pxc-release/*.tgz
+    - put: mysql-5-7-deployment
+      timeout: 2h
+      params:
+        manifest: backup-and-restore-sdk-release/ci/manifests/mysql.yml
+        stemcells:
+        - jammy-stemcell/*.tgz
+        vars:
+          mysql_version: "5.7"
+          deployment-name: *mysql-5-7-deployment-name
+          db_password: *mysql-password
+          db_host: *mysql-5-7-host
           availability_zone: z1
           <<: *mysql_certs_common
           vm_extensions: ["cf-tcp-router-network-properties"]
@@ -965,6 +1001,14 @@ jobs:
         TEST_TLS_MUTUAL_TLS: false
         <<: *bosh-smiths-creds
         <<: *mysql_params_8
+    - task: mysql-5-7-system-tests
+      file: backup-and-restore-sdk-release/ci/tasks/sdk-system-db/task.yml
+      params:
+        TEST_SUITE_NAME: mysql
+        TEST_TLS_VERIFY_IDENTITY: false
+        TEST_TLS_MUTUAL_TLS: false
+        <<: *bosh-smiths-creds
+        <<: *mysql_params_5_7
 
 - name: unclaim-cf-deployment-airgapped
   plan:

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -14,10 +14,18 @@ mysql/mysql-8.0.36-linux-glibc2.17-x86_64-minimal.tar.xz:
   size: 60593260
   object_id: 84707527-f032-4483-7b4f-8cb0808254f1
   sha: sha256:23d704336a8a31b513b706567cfca10a11e0a1bb71e25c1ade8e229400d6280c
+mysql/mysql-5.7.44.tar.gz:
+  size: 56570597
+  object_id: 92e82aaa-6a33-40b7-5940-2366d90ad636
+  sha: sha256:d03d8ff688862c40da3488451072a4b2178a86b53b4a7546ee5f864bb15cd919
 ncurses/ncurses-6.4.tar.gz:
   size: 3612591
   object_id: 2e99f0f8-be87-480b-4e5a-9488e923e4d1
   sha: sha256:6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159
+openssl/openssl-1.1.1w.tar.gz:
+  size: 9893384
+  object_id: 8ebd05e7-9a12-4a1c-7a2d-5142e99bbcc0
+  sha: sha256:cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
 postgres/postgresql-11.22.tar.gz:
   size: 26826810
   object_id: 00576d0f-f9a2-4210-7db0-f1d1687c3327

--- a/docs/database-backup-restore.md
+++ b/docs/database-backup-restore.md
@@ -33,7 +33,7 @@ The SDK accepts a JSON document with the following fields:
 #### Supported Database Adapters
 
 * `postgres` (auto-detects versions between `11` and `13`)
-* `mysql` (auto-detects `MariaDB 10.1.x` and `MySQL 8.0.x`. Any other `mysql` variants are not tested)
+* `mysql` (auto-detects `MariaDB 10.1.x`, `MySQL 5.7.x` and `MySQL 8.0.x`. Any other `mysql` variants are not tested)
 
 
 #### Deploying as an instance group

--- a/jobs/database-backup-restorer/templates/backup
+++ b/jobs/database-backup-restorer/templates/backup
@@ -32,6 +32,9 @@ export PG_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-postgres-15/b
 export MARIADB_DUMP_PATH="/var/vcap/packages/database-backup-restorer-mariadb/bin/mysqldump"
 export MARIADB_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-mariadb/bin/mysql"
 
+export MYSQL_DUMP_5_7_PATH="/var/vcap/packages/database-backup-restorer-mysql-5.7/bin/mysqldump"
+export MYSQL_CLIENT_5_7_PATH="/var/vcap/packages/database-backup-restorer-mysql-5.7/bin/mysql"
+
 export MYSQL_DUMP_8_0_PATH="/var/vcap/packages/database-backup-restorer-mysql-8.0/bin/mysqldump"
 export MYSQL_CLIENT_8_0_PATH="/var/vcap/packages/database-backup-restorer-mysql-8.0/bin/mysql"
 

--- a/jobs/database-backup-restorer/templates/restore
+++ b/jobs/database-backup-restorer/templates/restore
@@ -32,6 +32,9 @@ export PG_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-postgres-15/b
 export MARIADB_DUMP_PATH="/var/vcap/packages/database-backup-restorer-mariadb/bin/mysqldump"
 export MARIADB_CLIENT_PATH="/var/vcap/packages/database-backup-restorer-mariadb/bin/mysql"
 
+export MYSQL_DUMP_5_7_PATH="/var/vcap/packages/database-backup-restorer-mysql-5.7/bin/mysqldump"
+export MYSQL_CLIENT_5_7_PATH="/var/vcap/packages/database-backup-restorer-mysql-5.7/bin/mysql"
+
 export MYSQL_DUMP_8_0_PATH="/var/vcap/packages/database-backup-restorer-mysql-8.0/bin/mysqldump"
 export MYSQL_CLIENT_8_0_PATH="/var/vcap/packages/database-backup-restorer-mysql-8.0/bin/mysql"
 

--- a/packages/database-backup-restorer-mysql-5.7/packaging
+++ b/packages/database-backup-restorer-mysql-5.7/packaging
@@ -1,0 +1,79 @@
+# Copyright (C) 2017-Present Pivotal Software, Inc. All rights reserved.
+#
+# This program and the accompanying materials are made available under
+# the terms of the under the Apache License, Version 2.0 (the "License”);
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# abort script on any command that exits with a non zero value
+set -e
+
+MYSQL_VERSION=5.7.44
+MY_DIR=$(pwd)
+
+patch_file="$( mktemp )"
+echo '--- mysys/mf_iocache2.c 2019-08-05 09:42:13.000000000 +0000
++++ mysys/mf_iocache2.c.patched 2019-08-05 09:41:53.000000000 +0000
+@@ -17,6 +17,7 @@
+   More functions to be used with IO_CACHE files
+ */
+
++#include "mysql/psi/mysql_file.h"
+ #include "mysys_priv.h"
+ #include "my_sys.h"
+ #include <m_string.h>
+' > "$patch_file"
+
+tar xzf mysql/mysql-${MYSQL_VERSION}.tar.gz
+(
+  set -e
+  cd mysql-${MYSQL_VERSION}
+
+  patch mysys/mf_iocache2.c "$patch_file"
+
+  mkdir bld
+  cd bld
+
+  cmake .. \
+      -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET} \
+      -DWITHOUT_SERVER=ON \
+      -DWITH_SSL=system \
+      -DWITH_WSREP=ON \
+      -DWITH_INNODB_DISALLOW_WRITES=1 \
+      -DWITH_PCRE=bundled \
+      -DWITH_BOOST=/var/vcap/packages/database-backup-restorer-boost/boost_1_59_0
+
+  set +e
+  make -j 3 > build.out 2> build.err
+  BUILD_EXIT_CODE=$?
+  set -e
+
+  if [ $BUILD_EXIT_CODE -ne 0 ]; then
+      tail -n 1000 build.err
+      exit $BUILD_EXIT_CODE
+  fi
+  tail -n 1000 build.out
+
+  make install > build.out 2> build.err
+  BUILD_EXIT_CODE=$?
+  set -e
+
+  if [ $BUILD_EXIT_CODE -ne 0 ]; then
+      tail -n 1000 build.err
+      exit $BUILD_EXIT_CODE
+  fi
+  tail -n 1000 build.out
+
+  rm -rf ${BOSH_INSTALL_TARGET}/mysql-test/
+
+  echo -n "${MYSQL_VERSION}-MYSQL" > ${BOSH_INSTALL_TARGET}/VERSION
+)

--- a/packages/database-backup-restorer-mysql-5.7/spec
+++ b/packages/database-backup-restorer-mysql-5.7/spec
@@ -15,19 +15,10 @@
 # limitations under the License.
 
 ---
-name: database-backup-restorer
+name: database-backup-restorer-mysql-5.7
 
-templates:
-  backup: bin/backup
-  restore: bin/restore
+dependencies:
+- database-backup-restorer-boost
 
-packages:
-- database-backup-restorer
-- database-backup-restorer-postgres-11
-- database-backup-restorer-postgres-13
-- database-backup-restorer-postgres-15
-- database-backup-restorer-mariadb
-- database-backup-restorer-mysql-8.0
-- database-backup-restorer-mysql-5.7
-
-properties: {}
+files:
+- mysql/mysql-5.7.44.tar.gz

--- a/src/database-backup-restore/cmd/database-backup-restore/main.go
+++ b/src/database-backup-restore/cmd/database-backup-restore/main.go
@@ -61,7 +61,7 @@ func makeInteractor(isRestoreAction bool, utilitiesConfig config.UtilitiesConfig
 	connectionConfig config.ConnectionConfig, tempFolderManager config.TempFolderManager) (database.Interactor, error) {
 
 	postgresServerVersionDetector := postgres.NewServerVersionDetector(utilitiesConfig.Postgres11.Client)
-	mysqlServerVersionDetector := mysql.NewServerVersionDetector(utilitiesConfig.Mysql80.Client)
+	mysqlServerVersionDetector := mysql.NewServerVersionDetector(utilitiesConfig.Mysql57.Client)
 	interactorFactory := database.NewInteractorFactory(utilitiesConfig, postgresServerVersionDetector, mysqlServerVersionDetector, tempFolderManager)
 	return interactorFactory.Make(actionLabel(isRestoreAction), connectionConfig)
 }

--- a/src/database-backup-restore/config/utilities.go
+++ b/src/database-backup-restore/config/utilities.go
@@ -16,6 +16,7 @@ type UtilitiesConfig struct {
 	Postgres13 UtilityPaths
 	Postgres15 UtilityPaths
 	Mariadb    UtilityPaths
+	Mysql57    UtilityPaths
 	Mysql80    UtilityPaths
 }
 
@@ -40,6 +41,11 @@ func GetUtilitiesConfigFromEnv() UtilitiesConfig {
 			Client:  lookupEnv("MARIADB_CLIENT_PATH"),
 			Dump:    lookupEnv("MARIADB_DUMP_PATH"),
 			Restore: lookupEnv("MARIADB_CLIENT_PATH"),
+		},
+		Mysql57: UtilityPaths{
+			Client:  lookupEnv("MYSQL_CLIENT_5_7_PATH"),
+			Dump:    lookupEnv("MYSQL_DUMP_5_7_PATH"),
+			Restore: lookupEnv("MYSQL_CLIENT_5_7_PATH"),
 		},
 		Mysql80: UtilityPaths{
 			Client:  lookupEnv("MYSQL_CLIENT_8_0_PATH"),

--- a/src/database-backup-restore/database/interactor_factory.go
+++ b/src/database-backup-restore/database/interactor_factory.go
@@ -115,7 +115,10 @@ func (f InteractorFactory) getUtilitiesForMySQL(mysqlVersion version.DatabaseSer
 	case implementation == "mariadb" && semVer.MajorVersionMatches(version.SemVer("10", "x", "x")):
 		return f.utilitiesConfig.Mariadb.Dump, f.utilitiesConfig.Mariadb.Restore, nil
 	case implementation == "mysql":
-		if mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("8", "0", "0")) {
+		if mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("5", "7", "0")) {
+			return f.utilitiesConfig.Mysql57.Dump, f.utilitiesConfig.Mysql57.Restore, nil
+		}
+		if mysqlVersion.SemanticVersion.MajorVersionMatches(version.SemVer("8", "0", "0")) {
 			return f.utilitiesConfig.Mysql80.Dump, f.utilitiesConfig.Mysql80.Restore, nil
 		}
 	}
@@ -125,7 +128,7 @@ func (f InteractorFactory) getUtilitiesForMySQL(mysqlVersion version.DatabaseSer
 
 func (f InteractorFactory) getSSLCommandProvider(mysqlVersion version.DatabaseServerVersion) mysql.SSLOptionsProvider {
 	switch {
-	case mysqlVersion.SemanticVersion.MinorVersionMatches(version.SemVer("8", "0", "0")):
+	case mysqlVersion.SemanticVersion.MajorVersionMatches(version.SemVer("5", "7", "0")), mysqlVersion.SemanticVersion.MajorVersionMatches(version.SemVer("8", "0", "0")):
 		return mysql.NewDefaultSSLProvider(f.tempFolderManager)
 	default:
 		return mysql.NewLegacySSLOptionsProvider(f.tempFolderManager)

--- a/src/database-backup-restore/database/interactor_factory_test.go
+++ b/src/database-backup-restore/database/interactor_factory_test.go
@@ -43,6 +43,7 @@ var _ = Describe("InteractorFactory", func() {
 			Postgres13: config.UtilityPaths{Dump: "pg_p_13_dump", Restore: "pg_p_13_restore", Client: "pg_p_13_client"},
 			Postgres15: config.UtilityPaths{Dump: "pg_p_15_dump", Restore: "pg_p_15_restore", Client: "pg_p_15_client"},
 			Mariadb:    config.UtilityPaths{Dump: "mariadb_dump", Restore: "mariadb_restore", Client: "mariadb_client"},
+			Mysql57:    config.UtilityPaths{Dump: "mysql_57_dump", Restore: "mysql_57_restore", Client: "mysql_57_client"},
 			Mysql80:    config.UtilityPaths{Dump: "mysql_80_dump", Restore: "mysql_80_restore", Client: "mysql_80_client"},
 		}
 	})
@@ -321,7 +322,23 @@ var _ = Describe("InteractorFactory", func() {
 					))
 				})
 			})
+			Context("when the version is detected as MySQL 5.7.19", func() {
+				BeforeEach(func() {
+					mysqlServerVersionDetector.GetVersionReturns(
+						version.DatabaseServerVersion{
+							"mysql",
+							version.SemanticVersion{Major: "5", Minor: "7", Patch: "19"}}, nil)
+				})
 
+				It("builds a mysql.Restorer", func() {
+					Expect(factoryError).NotTo(HaveOccurred())
+					Expect(interactor).To(Equal(mysql.NewRestorer(
+						connectionConfig,
+						"mysql_57_restore",
+						mysql.NewDefaultSSLProvider(tempFolderManager),
+					)))
+				})
+			})
 			Context("when the version is detected as MySQL 8.0.27", func() {
 				BeforeEach(func() {
 					mysqlServerVersionDetector.GetVersionReturns(

--- a/src/database-backup-restore/integration_tests/database_backup_and_restore_suite_test.go
+++ b/src/database-backup-restore/integration_tests/database_backup_and_restore_suite_test.go
@@ -42,6 +42,8 @@ var fakePgRestore11 *binmock.Mock
 var fakePgRestore13 *binmock.Mock
 var fakePgRestore15 *binmock.Mock
 var fakePgClient *binmock.Mock
+var fakeMysqlClient57 *binmock.Mock
+var fakeMysqlDump57 *binmock.Mock
 var fakeMysqlClient80 *binmock.Mock
 var fakeMysqlDump80 *binmock.Mock
 var fakeMariaDBClient *binmock.Mock
@@ -62,6 +64,8 @@ var _ = BeforeSuite(func() {
 	fakePgRestore11 = binmock.NewBinMock(Fail)
 	fakePgRestore13 = binmock.NewBinMock(Fail)
 	fakePgRestore15 = binmock.NewBinMock(Fail)
+	fakeMysqlDump57 = binmock.NewBinMock(Fail)
+	fakeMysqlClient57 = binmock.NewBinMock(Fail)
 	fakeMysqlDump80 = binmock.NewBinMock(Fail)
 	fakeMysqlClient80 = binmock.NewBinMock(Fail)
 	fakeMariaDBClient = binmock.NewBinMock(Fail)
@@ -81,6 +85,8 @@ var _ = BeforeEach(func() {
 		"MARIADB_DUMP_PATH":     "non-existent",
 		"MYSQL_CLIENT_8_0_PATH": "non-existent",
 		"MYSQL_DUMP_8_0_PATH":   "non-existent",
+		"MYSQL_CLIENT_5_7_PATH": "non-existent",
+		"MYSQL_DUMP_5_7_PATH":   "non-existent",
 	}
 })
 

--- a/src/database-backup-restore/integration_tests/database_backup_restore_test.go
+++ b/src/database-backup-restore/integration_tests/database_backup_restore_test.go
@@ -157,6 +157,10 @@ var _ = Describe("Backup and Restore DB Utility", func() {
 			Entry("mariadb_client path missing", "MARIADB_CLIENT_PATH"),
 			Entry("mariadb_dump path missing", "MARIADB_DUMP_PATH"),
 			Entry("mariadb_client path missing", "MARIADB_CLIENT_PATH"),
+			Entry("mysql_client_8_0 path missing", "MYSQL_CLIENT_8_0_PATH"),
+			Entry("mysql_dump_8_0 path missing", "MYSQL_DUMP_8_0_PATH"),
+			Entry("mysql_client_5_7 path missing", "MYSQL_CLIENT_5_7_PATH"),
+			Entry("mysql_dump_5_7 path missing", "MYSQL_DUMP_5_7_PATH"),
 		)
 	})
 })

--- a/src/database-backup-restore/integration_tests/mysql_test.go
+++ b/src/database-backup-restore/integration_tests/mysql_test.go
@@ -39,12 +39,603 @@ var _ = Describe("MySQL", func() {
 	var err error
 	var configFile *os.File
 
+	Context("mysql 5.7", func() {
+		BeforeEach(func() {
+			artifactFile = tempFilePath()
+			fakeMysqlDump57.Reset()
+			fakeMysqlClient57.Reset()
+
+			envVars["MYSQL_CLIENT_5_7_PATH"] = fakeMysqlClient57.Path
+			envVars["MYSQL_DUMP_5_7_PATH"] = fakeMysqlDump57.Path
+		})
+
+		Context("backup", func() {
+			BeforeEach(func() {
+				configFile = saveFile(fmt.Sprintf(`{
+					"adapter":  "mysql",
+					"username": "%s",
+					"password": "%s",
+					"host":     "%s",
+					"port":     %d,
+					"database": "%s"
+				}`,
+					username,
+					password,
+					host,
+					port,
+					databaseName))
+			})
+
+			JustBeforeEach(func() {
+				cmd := exec.Command(
+					compiledSDKPath,
+					"--artifact-file",
+					artifactFile,
+					"--config",
+					configFile.Name(),
+					"--backup")
+
+				for key, val := range envVars {
+					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
+				}
+
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit())
+			})
+
+			Context("when mysqldump succeeds", func() {
+				BeforeEach(func() {
+					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("MYSQL server version 5.7.27")
+					fakeMysqlDump57.WhenCalled().WillExitWith(0)
+				})
+
+				It("calls mysql and mysqldump with the correct arguments", func() {
+					By("calling mysql to detect the version", func() {
+						Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+						Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+							fmt.Sprintf("--user=%s", username),
+							fmt.Sprintf("--host=%s", host),
+							fmt.Sprintf("--port=%d", port),
+							"--skip-column-names",
+							"--silent",
+							`--execute=SELECT VERSION()`,
+						))
+						Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					})
+
+					By("then calling dump", func() {
+						Expect(fakeMysqlDump57.Invocations()).To(HaveLen(1))
+						expectedArgs := []interface{}{
+							fmt.Sprintf("--user=%s", username),
+							fmt.Sprintf("--host=%s", host),
+							fmt.Sprintf("--port=%d", port),
+							"-v",
+							"--set-gtid-purged=OFF",
+							"--single-transaction",
+							"--skip-add-locks",
+							fmt.Sprintf("--result-file=%s", artifactFile),
+							databaseName,
+						}
+
+						Expect(fakeMysqlDump57.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+						Expect(fakeMysqlDump57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					})
+
+					Expect(session).Should(gexec.Exit(0))
+				})
+
+				Context("when 'tables' are specified in the configFile", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+					"adapter":  "mysql",
+					"username": "%s",
+					"password": "%s",
+					"host":     "%s",
+					"port":     %d,
+					"database": "%s",
+					"tables": ["table1", "table2", "table3"]
+				}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysqldump with the correct arguments", func() {
+						expectedArgs := []interface{}{
+							fmt.Sprintf("--user=%s", username),
+							fmt.Sprintf("--host=%s", host),
+							fmt.Sprintf("--port=%d", port),
+							"-v",
+							"--single-transaction",
+							"--set-gtid-purged=OFF",
+							"--skip-add-locks",
+							fmt.Sprintf("--result-file=%s", artifactFile),
+							databaseName,
+							"table1",
+							"table2",
+							"table3",
+						}
+
+						Expect(fakeMysqlDump57.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+					})
+				})
+
+				Context("when TLS is configured with hostname verification turned off", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+							"adapter":  "mysql",
+							"username": "%s",
+							"password": "%s",
+							"host":     "%s",
+							"port":     %d,
+							"database": "%s",
+							"tls": {
+								"skip_host_verify": true,
+								"cert": {
+									"ca": "A_CA_CERT"
+								}
+							}
+						}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysql and mysqldump with the correct arguments", func() {
+						By("calling mysql to detect the version", func() {
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								"--ssl-mode=VERIFY_CA",
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							))
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+								HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("then calling dump", func() {
+							expectedArgs := []interface{}{
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								"--ssl-mode=VERIFY_CA",
+								"--set-gtid-purged=OFF",
+								"-v",
+								"--single-transaction",
+								"--skip-add-locks",
+								fmt.Sprintf("--result-file=%s", artifactFile),
+								databaseName,
+							}
+
+							Expect(fakeMysqlDump57.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+						})
+					})
+				})
+
+				Context("when TLS is configured with client cert and private key", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+							"adapter":  "mysql",
+							"username": "%s",
+							"password": "%s",
+							"host":     "%s",
+							"port":     %d,
+							"database": "%s",
+							"tls": {
+								"cert": {
+									"ca": "A_CA_CERT",
+									"certificate": "A_CLIENT_CERT",
+									"private_key": "A_CLIENT_KEY"
+								}
+							}
+						}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysql and mysqldump with the correct arguments", func() {
+						By("calling mysql to detect the version", func() {
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								HavePrefix("--ssl-cert="),
+								HavePrefix("--ssl-key="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							))
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+								HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("then calling dump", func() {
+							expectedArgs := []interface{}{
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								HavePrefix("--ssl-cert="),
+								HavePrefix("--ssl-key="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"-v",
+								"--single-transaction",
+								"--skip-add-locks",
+								"--set-gtid-purged=OFF",
+								fmt.Sprintf("--result-file=%s", artifactFile),
+								databaseName,
+							}
+
+							Expect(fakeMysqlDump57.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+						})
+					})
+				})
+			})
+
+			Context("when version detection fails", func() {
+				BeforeEach(func() {
+					fakeMysqlClient57.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillExitWith(1).WillPrintToStdErr("VERSION DETECTION FAILED!")
+				})
+
+				It("also fails", func() {
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Eventually(session).Should(gexec.Exit(1))
+					Expect(session.Err).To(gbytes.Say("VERSION DETECTION FAILED!"))
+				})
+			})
+
+			Context("when mysqldump fails", func() {
+				BeforeEach(func() {
+					fakeMysqlClient57.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 5.6.38")
+					fakeMysqlDump57.WhenCalled().WillExitWith(1)
+				})
+
+				It("also fails", func() {
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Eventually(session).Should(gexec.Exit(1))
+				})
+			})
+
+			Context("when the server has an unsupported mysql major version", func() {
+				BeforeEach(func() {
+					fakeMysqlClient57.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 4.7.20")
+				})
+
+				It("fails because of a version mismatch", func() {
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(session).Should(gexec.Exit(1))
+					Expect(string(session.Err.Contents())).Should(ContainSubstring(
+						"unsupported version of mysql: 4.7"),
+					)
+				})
+			})
+			Context("when the server has a previously supported mysql version", func() {
+				BeforeEach(func() {
+					fakeMysqlClient57.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 5.6.1")
+				})
+
+				It("fails because of a version mismatch", func() {
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(session).Should(gexec.Exit(1))
+					Expect(string(session.Err.Contents())).Should(ContainSubstring(
+						"unsupported version of mysql: 5.6"),
+					)
+				})
+			})
+
+			Context("when the server has an unsupported mysql minor version", func() {
+				BeforeEach(func() {
+					fakeMysqlClient57.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 5.9.20")
+				})
+
+				It("fails because of a version mismatch", func() {
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(session).Should(gexec.Exit(1))
+					Expect(string(session.Err.Contents())).Should(ContainSubstring(
+						"unsupported version of mysql: 5.9"),
+					)
+				})
+			})
+
+			Context("when the server has a supported mysql minor version with a different patch to the packaged utility", func() {
+				BeforeEach(func() {
+					fakeMysqlDump57.WhenCalled().WillExitWith(0)
+					fakeMysqlClient57.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 5.7.27")
+				})
+
+				It("succeeds despite different patch versions", func() {
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(session).Should(gexec.Exit(0))
+				})
+			})
+		})
+
+		Context("restore", func() {
+			BeforeEach(func() {
+				configFile = saveFile(fmt.Sprintf(`{
+					"adapter":  "mysql",
+					"username": "%s",
+					"password": "%s",
+					"host":     "%s",
+					"port":     %d,
+					"database": "%s"
+				}`,
+					username,
+					password,
+					host,
+					port,
+					databaseName))
+			})
+
+			JustBeforeEach(func() {
+				err := os.WriteFile(artifactFile, []byte("SOME BACKUP SQL"), 0644)
+				Expect(err).ToNot(HaveOccurred())
+
+				cmd := exec.Command(
+					compiledSDKPath,
+					"--artifact-file",
+					artifactFile,
+					"--config",
+					configFile.Name(),
+					"--restore")
+
+				for key, val := range envVars {
+					cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, val))
+				}
+
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit())
+			})
+
+			Context("when mysql succeeds", func() {
+				BeforeEach(func() {
+					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("MYSQL server version 5.7.27")
+					fakeMysqlClient57.WhenCalled().WillExitWith(0)
+				})
+
+				Context("when TLS block is not configured", func() {
+					It("calls mysql with the correct arguments", func() {
+						By("calling mysql with the correct arguments for version checking", func() {
+							expectedVersionCheckArgs := []string{
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							}
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(2))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(expectedVersionCheckArgs))
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("calling mysql with the correct arguments for restoring", func() {
+							expectedRestoreArgs := []interface{}{
+								"-v",
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								databaseName,
+							}
+
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(2))
+							Expect(fakeMysqlClient57.Invocations()[1].Args()).Should(ConsistOf(expectedRestoreArgs))
+							Expect(fakeMysqlClient57.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+							Expect(fakeMysqlClient57.Invocations()[1].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("succeeding", func() {
+							Expect(session).Should(gexec.Exit(0))
+						})
+					})
+				})
+
+				Context("when TLS is configured", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+							"adapter":  "mysql",
+							"username": "%s",
+							"password": "%s",
+							"host":     "%s",
+							"port":     %d,
+							"database": "%s",
+							"tls": {
+								"cert": {
+									"ca": "A_CA_CERT"
+								}
+							}
+						}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysql with the correct arguments", func() {
+						By("calling mysql to detect the version", func() {
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(2))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							))
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("then calling mysql to restore", func() {
+							expectedArgs := []interface{}{
+								"-v",
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								databaseName,
+							}
+							Expect(fakeMysqlClient57.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
+							Expect(fakeMysqlClient57.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+						})
+					})
+				})
+
+				Context("when TLS is configured with client cert and private key", func() {
+					BeforeEach(func() {
+						configFile = saveFile(fmt.Sprintf(`{
+							"adapter":  "mysql",
+							"username": "%s",
+							"password": "%s",
+							"host":     "%s",
+							"port":     %d,
+							"database": "%s",
+							"tls": {
+								"cert": {
+									"ca": "A_CA_CERT",
+									"certificate": "A_CLIENT_CERT",
+									"private_key": "A_CLIENT_KEY"
+								}
+							}
+						}`,
+							username,
+							password,
+							host,
+							port,
+							databaseName))
+					})
+
+					It("calls mysql with the correct arguments", func() {
+						By("calling mysql to detect the version", func() {
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(2))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								HavePrefix("--ssl-cert="),
+								HavePrefix("--ssl-key="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"--skip-column-names",
+								"--silent",
+								`--execute=SELECT VERSION()`,
+							))
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
+								HaveKeyWithValue("MYSQL_PWD", password))
+						})
+
+						By("then calling mysql to restore", func() {
+							expectedArgs := []interface{}{
+								fmt.Sprintf("--user=%s", username),
+								fmt.Sprintf("--host=%s", host),
+								fmt.Sprintf("--port=%d", port),
+								HavePrefix("--ssl-ca="),
+								HavePrefix("--ssl-cert="),
+								HavePrefix("--ssl-key="),
+								"--ssl-mode=VERIFY_IDENTITY",
+								"-v",
+								databaseName,
+							}
+
+							Expect(fakeMysqlClient57.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
+							Expect(fakeMysqlClient57.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+						})
+					})
+				})
+			})
+
+			Context("when mysql fails", func() {
+				BeforeEach(func() {
+					fakeMysqlClient57.WhenCalledWith(
+						fmt.Sprintf("--user=%s", username),
+						fmt.Sprintf("--host=%s", host),
+						fmt.Sprintf("--port=%d", port),
+						"--skip-column-names",
+						"--silent",
+						`--execute=SELECT VERSION()`,
+					).WillPrintToStdOut("MYSQL server version 5.7.27")
+					fakeMysqlClient57.WhenCalled().WillExitWith(1)
+				})
+
+				It("also fails", func() {
+					Expect(fakeMysqlClient57.Invocations()).To(HaveLen(2))
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Eventually(session).Should(gexec.Exit(1))
+				})
+			})
+		})
+	})
 	Context("mysql 8.0", func() {
 		BeforeEach(func() {
 			artifactFile = tempFilePath()
+			fakeMysqlClient57.Reset()
 			fakeMysqlDump80.Reset()
 			fakeMysqlClient80.Reset()
 
+			envVars["MYSQL_CLIENT_5_7_PATH"] = fakeMysqlClient57.Path
 			envVars["MYSQL_CLIENT_8_0_PATH"] = fakeMysqlClient80.Path
 			envVars["MYSQL_DUMP_8_0_PATH"] = fakeMysqlDump80.Path
 		})
@@ -86,14 +677,14 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysqldump succeeds", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("MYSQL server version 8.0.27")
+					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("MYSQL server version 8.0.27")
 					fakeMysqlDump80.WhenCalled().WillExitWith(0)
 				})
 
 				It("calls mysql and mysqldump with the correct arguments", func() {
 					By("calling mysql to detect the version", func() {
-						Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
-						Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+						Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+						Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
 							fmt.Sprintf("--user=%s", username),
 							fmt.Sprintf("--host=%s", host),
 							fmt.Sprintf("--port=%d", port),
@@ -101,7 +692,7 @@ var _ = Describe("MySQL", func() {
 							"--silent",
 							`--execute=SELECT VERSION()`,
 						))
-						Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+						Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					})
 
 					By("then calling dump", func() {
@@ -188,8 +779,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql and mysqldump with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -199,7 +790,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -249,8 +840,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql and mysqldump with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
-							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -262,7 +853,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -291,7 +882,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when version detection fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalledWith(
+					fakeMysqlClient57.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -302,7 +893,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 					Expect(session.Err).To(gbytes.Say("VERSION DETECTION FAILED!"))
 				})
@@ -310,26 +901,26 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysqldump fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalledWith(
+					fakeMysqlClient57.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
 						"--skip-column-names",
 						"--silent",
 						`--execute=SELECT VERSION()`,
-					).WillPrintToStdOut("MYSQL server version 5.6.38")
+					).WillPrintToStdOut("MYSQL server version 8.0.38")
 					fakeMysqlDump80.WhenCalled().WillExitWith(1)
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 				})
 			})
 
 			Context("when the server has an unsupported mysql major version", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalledWith(
+					fakeMysqlClient57.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -340,7 +931,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("fails because of a version mismatch", func() {
-					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(1))
 					Expect(string(session.Err.Contents())).Should(ContainSubstring(
 						"unsupported version of mysql: 4.7"),
@@ -349,28 +940,28 @@ var _ = Describe("MySQL", func() {
 			})
 			Context("when the server has a reviously supported mysql version", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalledWith(
+					fakeMysqlClient57.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
 						"--skip-column-names",
 						"--silent",
 						`--execute=SELECT VERSION()`,
-					).WillPrintToStdOut("MYSQL server version 5.7.20")
+					).WillPrintToStdOut("MYSQL server version 5.6.20")
 				})
 
 				It("fails because of a version mismatch", func() {
-					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(1))
 					Expect(string(session.Err.Contents())).Should(ContainSubstring(
-						"unsupported version of mysql: 5.7"),
+						"unsupported version of mysql: 5.6"),
 					)
 				})
 			})
 
 			Context("when the server has an unsupported mysql minor version", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalledWith(
+					fakeMysqlClient57.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -381,7 +972,7 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("fails because of a version mismatch", func() {
-					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Expect(session).Should(gexec.Exit(1))
 					Expect(string(session.Err.Contents())).Should(ContainSubstring(
 						"unsupported version of mysql: 5.9"),
@@ -392,18 +983,19 @@ var _ = Describe("MySQL", func() {
 			Context("when the server has a supported mysql minor version with a different patch to the packaged utility", func() {
 				BeforeEach(func() {
 					fakeMysqlDump80.WhenCalled().WillExitWith(0)
-					fakeMysqlClient80.WhenCalledWith(
+					fakeMysqlClient57.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
 						"--skip-column-names",
 						"--silent",
 						`--execute=SELECT VERSION()`,
-					).WillPrintToStdOut("MYSQL server version 8.0.27")
+					).WillPrintToStdOut("MYSQL server version 8.0.666")
 				})
 
 				It("succeeds despite different patch versions", func() {
-					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlDump80.Invocations()).Should(HaveLen(1))
 					Expect(session).Should(gexec.Exit(0))
 				})
 			})
@@ -449,7 +1041,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysql succeeds", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("MYSQL server version 8.0.27")
+					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("MYSQL server version 8.0.27")
 					fakeMysqlClient80.WhenCalled().WillExitWith(0)
 				})
 
@@ -464,9 +1056,9 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							}
-							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
-							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(expectedVersionCheckArgs))
-							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(expectedVersionCheckArgs))
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
 						By("calling mysql with the correct arguments for restoring", func() {
@@ -478,10 +1070,10 @@ var _ = Describe("MySQL", func() {
 								databaseName,
 							}
 
-							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
-							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedRestoreArgs))
-							Expect(fakeMysqlClient80.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
-							Expect(fakeMysqlClient80.Invocations()[1].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(expectedRestoreArgs))
+							Expect(fakeMysqlClient80.Invocations()[0].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
 						By("succeeding", func() {
@@ -514,8 +1106,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
-							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -525,7 +1117,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
 						By("then calling mysql to restore", func() {
@@ -539,8 +1131,9 @@ var _ = Describe("MySQL", func() {
 								databaseName,
 							}
 
-							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
-							Expect(fakeMysqlClient80.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+							Expect(fakeMysqlClient80.Invocations()[0].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
 						})
 					})
 				})
@@ -571,8 +1164,8 @@ var _ = Describe("MySQL", func() {
 
 					It("calls mysql with the correct arguments", func() {
 						By("calling mysql to detect the version", func() {
-							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
-							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(
+							Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient57.Invocations()[0].Args()).Should(ConsistOf(
 								fmt.Sprintf("--user=%s", username),
 								fmt.Sprintf("--host=%s", host),
 								fmt.Sprintf("--port=%d", port),
@@ -584,7 +1177,7 @@ var _ = Describe("MySQL", func() {
 								"--silent",
 								`--execute=SELECT VERSION()`,
 							))
-							Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(
+							Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(
 								HaveKeyWithValue("MYSQL_PWD", password))
 						})
 
@@ -601,8 +1194,9 @@ var _ = Describe("MySQL", func() {
 								databaseName,
 							}
 
-							Expect(fakeMysqlClient80.Invocations()[1].Args()).Should(ConsistOf(expectedArgs))
-							Expect(fakeMysqlClient80.Invocations()[1].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
+							Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+							Expect(fakeMysqlClient80.Invocations()[0].Args()).Should(ConsistOf(expectedArgs))
+							Expect(fakeMysqlClient80.Invocations()[0].Stdin()).Should(ConsistOf("SOME BACKUP SQL"))
 						})
 					})
 				})
@@ -610,7 +1204,7 @@ var _ = Describe("MySQL", func() {
 
 			Context("when mysql fails", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalledWith(
+					fakeMysqlClient57.WhenCalledWith(
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),
 						fmt.Sprintf("--port=%d", port),
@@ -622,8 +1216,9 @@ var _ = Describe("MySQL", func() {
 				})
 
 				It("also fails", func() {
-					Expect(fakeMysqlClient80.Invocations()).To(HaveLen(2))
-					Expect(fakeMysqlClient80.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
+					Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+					Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
+					Expect(fakeMysqlClient57.Invocations()[0].Env()).Should(HaveKeyWithValue("MYSQL_PWD", password))
 					Eventually(session).Should(gexec.Exit(1))
 				})
 			})
@@ -647,9 +1242,9 @@ var _ = Describe("MariaDB", func() {
 		BeforeEach(func() {
 			artifactFile = tempFilePath()
 			fakeMariaDBDump.Reset()
-			fakeMysqlClient80.Reset()
+			fakeMysqlClient57.Reset()
 
-			envVars["MYSQL_CLIENT_8_0_PATH"] = fakeMysqlClient80.Path
+			envVars["MYSQL_CLIENT_5_7_PATH"] = fakeMysqlClient57.Path
 			envVars["MARIADB_DUMP_PATH"] = fakeMariaDBDump.Path
 		})
 
@@ -690,13 +1285,13 @@ var _ = Describe("MariaDB", func() {
 
 			Context("when mysqldump succeeds", func() {
 				BeforeEach(func() {
-					fakeMysqlClient80.WhenCalled().WillPrintToStdOut("10.1.34-MariaDB")
+					fakeMysqlClient57.WhenCalled().WillPrintToStdOut("10.1.34-MariaDB")
 					fakeMariaDBDump.WhenCalled().WillExitWith(0)
 				})
 
 				It("calls mysqldump with the correct arguments", func() {
-					Expect(fakeMysqlClient80.Invocations()).To(HaveLen(1))
-					//Expect(fakeMariaDBDump.Invocations()).To(HaveLen(1))
+					Expect(fakeMysqlClient57.Invocations()).To(HaveLen(1))
+					Expect(fakeMariaDBDump.Invocations()).To(HaveLen(1))
 					expectedArgs := []interface{}{
 						fmt.Sprintf("--user=%s", username),
 						fmt.Sprintf("--host=%s", host),


### PR DESCRIPTION
[#186981469]

partial revert of:
https://github.com/cloudfoundry/backup-and-restore-sdk-release/pull/1455

The above PR removed support for mysql 5.7 from BBR. This has caused breakage for some consumers since they still support mysql 5.7.

Changes not reverted:

- Openssl lib can still be removed. Mysql 5.7.43 started supporting to build against openssl3 ( see https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-43.html)

So we can stop shipping a custom openssl lib in the release ( not supporting ossl3 prior to 5.7.43 broke building mysql 5.7 on jammy stemcells ) and was added to keep supporting compilation of 5.7 client binaries on jammy.