### PR TITLE
[ci] Install Ruby version if not present

### DIFF
--- a/ci/tasks/sdk-template-unit-tests/task.yml
+++ b/ci/tasks/sdk-template-unit-tests/task.yml
@@ -9,9 +9,9 @@ inputs:
 run:
   path: bash
   args:
+    - -e
     - -c
-    - set -e
-
+    - |
       pushd "backup-and-restore-sdk-release"
         rbenv install --skip-existing # Install .ruby-version if not present
         bundle install

--- a/ci/tasks/sdk-template-unit-tests/task.yml
+++ b/ci/tasks/sdk-template-unit-tests/task.yml
@@ -10,5 +10,10 @@ run:
   path: bash
   args:
     - -c
-    - "set -e\n\npushd \"backup-and-restore-sdk-release\"\n  bundle update --bundler\n\
-      \  bundle\n  bundle exec rspec\npopd\n"
+    - set -e
+
+      pushd "backup-and-restore-sdk-release"
+        rbenv install --skip-existing # Install .ruby-version if not present
+        bundle install
+        bundle exec rspec
+      popd


### PR DESCRIPTION
- cryogenics/essentials uses the most recent Ruby version available across all Shepherd envs
- it is possible that the Ruby version across all envs is not the version required by bbr