### PR TITLE
Remove unused OpenSSL 1.1 blob

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -22,10 +22,6 @@ ncurses/ncurses-6.5.tar.gz:
   size: 3688489
   object_id: 44145765-7530-4a4b-45fd-932d16aa3aa4
   sha: sha256:136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6
-openssl/openssl-1.1.1w.tar.gz:
-  size: 9893384
-  object_id: 8ebd05e7-9a12-4a1c-7a2d-5142e99bbcc0
-  sha: sha256:cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
 postgres/postgresql-11.22.tar.gz:
   size: 26826810
   object_id: 00576d0f-f9a2-4210-7db0-f1d1687c3327


### PR DESCRIPTION
This was previously used with MySQL 5.7, but the dependency was removed when the 5.7 package was restored.