### PR TITLE
update the expected error message when testing listing gcs buckets

### DIFF
--- a/src/gcs-blobstore-backup-restore/contract_test/bucket_test.go
+++ b/src/gcs-blobstore-backup-restore/contract_test/bucket_test.go
@@ -213,8 +213,7 @@ var _ = Describe("Bucket", func() {
 				backupsToComplete, err := gcs.BuildBackupsToComplete(MustHaveEnv("GCP_SERVICE_ACCOUNT_KEY"), config)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = backupsToComplete["droplets"].BucketPair.LiveBucket.ListBlobs("")
-				Expect(err).To(MatchError("storage: bucket doesn't exist"))
-			})
+				Expect(err).To(MatchError(ContainSubstring("storage: bucket doesn't exist")))
 		})
 	})
 


### PR DESCRIPTION
the error message details changed with the latest gcs updates and the test was failing since it didn't match the error text