### PR TITLE
rearrange the order of ginkgo flags

### DIFF
--- a/ci/tasks/sdk-system-db/task.sh
+++ b/ci/tasks/sdk-system-db/task.sh
@@ -30,4 +30,4 @@ export BOSH_GW_PRIVATE_KEY="$ssh_proxy_key"
 export BOSH_ALL_PROXY="ssh+socks5://${BOSH_GW_USER}@${BOSH_GW_HOST}:22?private-key=${ssh_proxy_key}"
 
 cd backup-and-restore-sdk-release/src/database-backup-restore
-go run github.com/onsi/ginkgo/v2/ginkgo -mod vendor -v -r "system_tests/${TEST_SUITE_NAME}" --trace
+go run github.com/onsi/ginkgo/v2/ginkgo -r -v --trace -mod vendor "system_tests/${TEST_SUITE_NAME}"


### PR DESCRIPTION
to resolve this error:
```
ginkgo run failed
  Malformed arguments - detected a flag after the package liste
    Make sure all flags appear after the Ginkgo subcommand and before your list of
    packages (or './...').
    e.g. 'ginkgo run -p my_package' is valid but `ginkgo -p run my_package` is
    not.
    e.g. 'ginkgo -p -vet ./...' is valid but 'ginkgo -p ./... -vet' is not
```