### PR TITLE
ci: Bump MySQL 8.4 w/ glibc 2.28 version

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1933,7 +1933,7 @@ jobs:
       GIT_BRANCH: main
       BLOB_NAME: mysql
       KEEP_BLOBS_FILTER: mysql-5,mysql-8.0
-      BLOB_EXTENSION: linux-glibc2.17-x86_64-minimal.tar.xz
+      BLOB_EXTENSION: linux-glibc2.28-x86_64-minimal.tar.xz
       BLOB_DIRECTORY: mysql/
       UPDATE_REFERENCES: only-variable-name:MYSQL84_VERSION
   # Push changes


### PR DESCRIPTION
MySQL.com offers two versions of MySQL 8.4 - one compiled using glibc 2.17, one with 2.28. When we added 8.4, we manually added a the glibc 2.17 blob. However, the pipeline is pulling the highest version available, which translates into the glibc 2.28 version.

Jammy is bundled with glibc 2.35, so there doesn't seem to be a reason to lock to the older glibc version.

ai-assisted=no

Already flown to the pipeline.