### PR TITLE
Validate restore artifact bucket coordinates against operator config

### DIFF
--- a/src/s3-blobstore-backup-restore/unversioned/config.go
+++ b/src/s3-blobstore-backup-restore/unversioned/config.go
@@ -166,8 +166,6 @@ func BuildRestoreBucketPairs(
 	artifact incremental.Artifact,
 	newBucket NewBucket,
 ) (map[string]incremental.RestoreBucketPair, error) {
-	pairs := map[string]incremental.RestoreBucketPair{}
-
 	backups, err := artifact.Load()
 	if err != nil {
 		return nil, err
@@ -178,6 +176,27 @@ func BuildRestoreBucketPairs(
 			return nil, fmt.Errorf("backup artifact does not contain bucket ID '%s'", bucketID)
 		}
 
+		if backups[bucketID].SameBucketAs != "" {
+			continue
+		}
+
+		if backups[bucketID].BucketName != config.Backup.Name {
+			return nil, fmt.Errorf(
+				"artifact bucket name %q for bucket ID %q does not match configured backup bucket name %q",
+				backups[bucketID].BucketName, bucketID, config.Backup.Name,
+			)
+		}
+		if backups[bucketID].BucketRegion != config.Backup.Region {
+			return nil, fmt.Errorf(
+				"artifact bucket region %q for bucket ID %q does not match configured backup bucket region %q",
+				backups[bucketID].BucketRegion, bucketID, config.Backup.Region,
+			)
+		}
+	}
+
+	pairs := map[string]incremental.RestoreBucketPair{}
+
+	for bucketID, config := range configs {
 		if backups[bucketID].SameBucketAs != "" {
 			pairs[bucketID] = incremental.RestoreBucketPair{
 				SameAsBucketID: backups[bucketID].SameBucketAs,
@@ -207,8 +226,8 @@ func BuildRestoreBucketPairs(
 		}
 
 		backupBucket, err := newBucket(
-			backups[bucketID].BucketName,
-			backups[bucketID].BucketRegion,
+			config.Backup.Name,
+			config.Backup.Region,
 			config.Endpoint,
 			config.AwsAssumedRoleArn,
 			s3bucket.AccessKey{

--- a/src/s3-blobstore-backup-restore/unversioned/config_test.go
+++ b/src/s3-blobstore-backup-restore/unversioned/config_test.go
@@ -574,5 +574,65 @@ var _ = Describe("Unversioned", func() {
 
 			Expect(err).To(MatchError(ContainSubstring("backup artifact does not contain bucket ID")))
 		})
+
+		Context("when the artifact bucket name does not match the configured backup bucket name", func() {
+			It("returns an error without constructing any bucket", func() {
+				artifact.LoadReturns(map[string]incremental.Backup{
+					"bucket1": {
+						BucketName:             "tampered-bucket",
+						BucketRegion:           "backup-region1",
+						SrcBackupDirectoryPath: "destination-backup-dir1",
+					},
+					"bucket2": {
+						BucketName:             "backup-name2",
+						BucketRegion:           "backup-region2",
+						SrcBackupDirectoryPath: "destination-backup-dir2",
+					},
+				}, nil)
+
+				newBucketCallCount := 0
+				countingNewBucket := func(bucketName, bucketRegion, endpoint, roleArn string, accessKey s3bucket.AccessKey, useIAMProfile, forcePathStyle bool) (unversioned.Bucket, error) {
+					newBucketCallCount++
+					return newBucket(bucketName, bucketRegion, endpoint, roleArn, accessKey, useIAMProfile, forcePathStyle)
+				}
+
+				_, err := unversioned.BuildRestoreBucketPairs(configs, artifact, countingNewBucket)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`artifact bucket name "tampered-bucket"`))
+				Expect(err.Error()).To(ContainSubstring(`does not match configured backup bucket name "backup-name1"`))
+				Expect(newBucketCallCount).To(Equal(0))
+			})
+		})
+
+		Context("when the artifact bucket region does not match the configured backup bucket region", func() {
+			It("returns an error without constructing any bucket", func() {
+				artifact.LoadReturns(map[string]incremental.Backup{
+					"bucket1": {
+						BucketName:             "backup-name1",
+						BucketRegion:           "tampered-region",
+						SrcBackupDirectoryPath: "destination-backup-dir1",
+					},
+					"bucket2": {
+						BucketName:             "backup-name2",
+						BucketRegion:           "backup-region2",
+						SrcBackupDirectoryPath: "destination-backup-dir2",
+					},
+				}, nil)
+
+				newBucketCallCount := 0
+				countingNewBucket := func(bucketName, bucketRegion, endpoint, roleArn string, accessKey s3bucket.AccessKey, useIAMProfile, forcePathStyle bool) (unversioned.Bucket, error) {
+					newBucketCallCount++
+					return newBucket(bucketName, bucketRegion, endpoint, roleArn, accessKey, useIAMProfile, forcePathStyle)
+				}
+
+				_, err := unversioned.BuildRestoreBucketPairs(configs, artifact, countingNewBucket)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`artifact bucket region "tampered-region"`))
+				Expect(err.Error()).To(ContainSubstring(`does not match configured backup bucket region "backup-region1"`))
+				Expect(newBucketCallCount).To(Equal(0))
+			})
+		})
 	})
 })

--- a/src/s3-blobstore-backup-restore/versioned/restorer.go
+++ b/src/s3-blobstore-backup-restore/versioned/restorer.go
@@ -34,6 +34,23 @@ func (r Restorer) Run() error {
 			return fmt.Errorf("no entry found in backup artifact for bucket: %s", identifier)
 		}
 
+		if bucketSnapshot.BucketName != destinationBucket.Name() {
+			return fmt.Errorf(
+				"artifact bucket name %q for bucket %q does not match configured bucket name %q",
+				bucketSnapshot.BucketName, identifier, destinationBucket.Name(),
+			)
+		}
+		if bucketSnapshot.RegionName != destinationBucket.Region() {
+			return fmt.Errorf(
+				"artifact bucket region %q for bucket %q does not match configured bucket region %q",
+				bucketSnapshot.RegionName, identifier, destinationBucket.Region(),
+			)
+		}
+	}
+
+	for identifier, destinationBucket := range r.destinationBuckets {
+		bucketSnapshot := bucketSnapshots[identifier]
+
 		isVersioned, err := destinationBucket.IsVersioned()
 
 		if err != nil {
@@ -48,8 +65,8 @@ func (r Restorer) Run() error {
 			err = destinationBucket.CopyVersion(
 				versionToCopy.BlobKey,
 				versionToCopy.Id,
-				bucketSnapshot.BucketName,
-				bucketSnapshot.RegionName,
+				destinationBucket.Name(),
+				destinationBucket.Region(),
 			)
 
 			if err != nil {

--- a/src/s3-blobstore-backup-restore/versioned/restorer_test.go
+++ b/src/s3-blobstore-backup-restore/versioned/restorer_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Restorer", func() {
 			artifact.LoadReturns(map[string]versioned.BucketSnapshot{
 				"droplets": {
 					BucketName: "my_droplets_bucket",
-					RegionName: "my_droplets_source_region",
+					RegionName: "my_droplets_region",
 					Versions: []versioned.BlobVersion{
 						{BlobKey: "one", Id: "13"},
 						{BlobKey: "two", Id: "22"},
@@ -58,14 +58,14 @@ var _ = Describe("Restorer", func() {
 				},
 				"buildpacks": {
 					BucketName: "my_buildpacks_bucket",
-					RegionName: "my_buildpacks_source_region",
+					RegionName: "my_buildpacks_region",
 					Versions: []versioned.BlobVersion{
 						{BlobKey: "three", Id: "32"},
 					},
 				},
 				"packages": {
 					BucketName: "my_packages_bucket",
-					RegionName: "my_packages_source_region",
+					RegionName: "my_packages_region",
 					Versions: []versioned.BlobVersion{
 						{BlobKey: "four", Id: "43"},
 					},
@@ -75,12 +75,15 @@ var _ = Describe("Restorer", func() {
 			dropletsBucket.CopyVersionReturns(nil)
 			buildpacksBucket.CopyVersionReturns(nil)
 			packagesBucket.CopyVersionReturns(nil)
-			dropletsBucket.RegionReturns("destination_droplets_region")
-			buildpacksBucket.RegionReturns("destination_buildpacks_region")
-			packagesBucket.RegionReturns("destination_packages_region")
+			dropletsBucket.NameReturns("my_droplets_bucket")
+			dropletsBucket.RegionReturns("my_droplets_region")
+			buildpacksBucket.NameReturns("my_buildpacks_bucket")
+			buildpacksBucket.RegionReturns("my_buildpacks_region")
+			packagesBucket.NameReturns("my_packages_bucket")
+			packagesBucket.RegionReturns("my_packages_region")
 		})
 
-		It("restores a backup from one region to a new foundation in a different region", func() {
+		It("copies each version from the artifact to the destination buckets", func() {
 			By("successfully running", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -91,43 +94,113 @@ var _ = Describe("Restorer", func() {
 				Expect(packagesBucket.IsVersionedCallCount()).To(Equal(1))
 			})
 
-			By("Calling CopyVersion for each object in the droplets bucket with the old region", func() {
+			By("Calling CopyVersion for each object in the droplets bucket", func() {
 				Expect(dropletsBucket.CopyVersionCallCount()).To(Equal(2))
 
 				expectedBlobKey, expectedVersionId, expectedSourceBucketName, expectedSourceRegionName := dropletsBucket.CopyVersionArgsForCall(0)
 				Expect(expectedBlobKey).To(Equal("one"))
 				Expect(expectedVersionId).To(Equal("13"))
 				Expect(expectedSourceBucketName).To(Equal("my_droplets_bucket"))
-				Expect(expectedSourceRegionName).To(Equal("my_droplets_source_region"))
+				Expect(expectedSourceRegionName).To(Equal("my_droplets_region"))
 
 				expectedBlobKey, expectedVersionId, expectedSourceBucketName, expectedSourceRegionName = dropletsBucket.CopyVersionArgsForCall(1)
 				Expect(expectedBlobKey).To(Equal("two"))
 				Expect(expectedVersionId).To(Equal("22"))
 				Expect(expectedSourceBucketName).To(Equal("my_droplets_bucket"))
-				Expect(expectedSourceRegionName).To(Equal("my_droplets_source_region"))
+				Expect(expectedSourceRegionName).To(Equal("my_droplets_region"))
 			})
 
-			By("Calling CopyVersions for each object in the buildpacks bucket with the old region", func() {
+			By("Calling CopyVersions for each object in the buildpacks bucket", func() {
 				Expect(buildpacksBucket.CopyVersionCallCount()).To(Equal(1))
 
 				expectedBlobKey, expectedVersionId, expectedSourceBucketName, expectedSourceRegionName := buildpacksBucket.CopyVersionArgsForCall(0)
 				Expect(expectedBlobKey).To(Equal("three"))
 				Expect(expectedVersionId).To(Equal("32"))
 				Expect(expectedSourceBucketName).To(Equal("my_buildpacks_bucket"))
-				Expect(expectedSourceRegionName).To(Equal("my_buildpacks_source_region"))
+				Expect(expectedSourceRegionName).To(Equal("my_buildpacks_region"))
 			})
 
-			By("Calling CopyVersions for each object in the packages bucket with the old region", func() {
+			By("Calling CopyVersions for each object in the packages bucket", func() {
 				Expect(packagesBucket.CopyVersionCallCount()).To(Equal(1))
 
 				expectedBlobKey, expectedVersionId, expectedSourceBucketName, expectedSourceRegionName := packagesBucket.CopyVersionArgsForCall(0)
 				Expect(expectedBlobKey).To(Equal("four"))
 				Expect(expectedVersionId).To(Equal("43"))
 				Expect(expectedSourceBucketName).To(Equal("my_packages_bucket"))
-				Expect(expectedSourceRegionName).To(Equal("my_packages_source_region"))
+				Expect(expectedSourceRegionName).To(Equal("my_packages_region"))
 			})
 		})
 
+	})
+
+	Context("when the artifact bucket name does not match the configured bucket name", func() {
+		BeforeEach(func() {
+			artifact.LoadReturns(map[string]versioned.BucketSnapshot{
+				"droplets": {
+					BucketName: "tampered-bucket",
+					RegionName: "my_droplets_region",
+					Versions:   []versioned.BlobVersion{{BlobKey: "one", Id: "13"}},
+				},
+				"buildpacks": {
+					BucketName: "my_buildpacks_bucket",
+					RegionName: "my_buildpacks_region",
+					Versions:   []versioned.BlobVersion{{BlobKey: "three", Id: "32"}},
+				},
+			}, nil)
+			restorer = versioned.NewRestorer(map[string]versioned.Bucket{
+				"droplets":   dropletsBucket,
+				"buildpacks": buildpacksBucket,
+			}, artifact)
+			dropletsBucket.NameReturns("my_droplets_bucket")
+			dropletsBucket.RegionReturns("my_droplets_region")
+			buildpacksBucket.NameReturns("my_buildpacks_bucket")
+			buildpacksBucket.RegionReturns("my_buildpacks_region")
+		})
+
+		It("returns an error without calling IsVersioned or CopyVersion on any bucket", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`artifact bucket name "tampered-bucket"`))
+			Expect(err.Error()).To(ContainSubstring(`does not match configured bucket name "my_droplets_bucket"`))
+			Expect(dropletsBucket.IsVersionedCallCount()).To(Equal(0))
+			Expect(dropletsBucket.CopyVersionCallCount()).To(Equal(0))
+			Expect(buildpacksBucket.IsVersionedCallCount()).To(Equal(0))
+			Expect(buildpacksBucket.CopyVersionCallCount()).To(Equal(0))
+		})
+	})
+
+	Context("when the artifact bucket region does not match the configured bucket region", func() {
+		BeforeEach(func() {
+			artifact.LoadReturns(map[string]versioned.BucketSnapshot{
+				"droplets": {
+					BucketName: "my_droplets_bucket",
+					RegionName: "tampered-region",
+					Versions:   []versioned.BlobVersion{{BlobKey: "one", Id: "13"}},
+				},
+				"buildpacks": {
+					BucketName: "my_buildpacks_bucket",
+					RegionName: "my_buildpacks_region",
+					Versions:   []versioned.BlobVersion{{BlobKey: "three", Id: "32"}},
+				},
+			}, nil)
+			restorer = versioned.NewRestorer(map[string]versioned.Bucket{
+				"droplets":   dropletsBucket,
+				"buildpacks": buildpacksBucket,
+			}, artifact)
+			dropletsBucket.NameReturns("my_droplets_bucket")
+			dropletsBucket.RegionReturns("my_droplets_region")
+			buildpacksBucket.NameReturns("my_buildpacks_bucket")
+			buildpacksBucket.RegionReturns("my_buildpacks_region")
+		})
+
+		It("returns an error without calling IsVersioned or CopyVersion on any bucket", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`artifact bucket region "tampered-region"`))
+			Expect(err.Error()).To(ContainSubstring(`does not match configured bucket region "my_droplets_region"`))
+			Expect(dropletsBucket.IsVersionedCallCount()).To(Equal(0))
+			Expect(dropletsBucket.CopyVersionCallCount()).To(Equal(0))
+			Expect(buildpacksBucket.IsVersionedCallCount()).To(Equal(0))
+			Expect(buildpacksBucket.CopyVersionCallCount()).To(Equal(0))
+		})
 	})
 
 	Context("when the artifact fails to load", func() {
@@ -170,6 +243,13 @@ var _ = Describe("Restorer", func() {
 				},
 			}, nil)
 
+			dropletsBucket.NameReturns("my_droplets_bucket")
+			dropletsBucket.RegionReturns("my_droplets_region")
+			buildpacksBucket.NameReturns("my_buildpacks_bucket")
+			buildpacksBucket.RegionReturns("my_buildpacks_region")
+			packagesBucket.NameReturns("my_packages_bucket")
+			packagesBucket.RegionReturns("my_packages_region")
+
 			dropletsBucket.CopyVersionReturns(nil)
 			buildpacksBucket.CopyVersionReturns(errors.New("failed to put version to bucket 'buildpacks'"))
 			packagesBucket.CopyVersionReturns(nil)
@@ -207,12 +287,18 @@ var _ = Describe("Restorer", func() {
 				},
 			}, nil)
 
+			dropletsBucket.NameReturns("my_droplets_bucket")
+			dropletsBucket.RegionReturns("my_droplets_region")
+			buildpacksBucket.NameReturns("my_buildpacks_bucket")
+			buildpacksBucket.RegionReturns("my_buildpacks_region")
+			packagesBucket.NameReturns("my_packages_bucket")
+			packagesBucket.RegionReturns("my_packages_region")
+
 			dropletsBucket.CopyVersionReturns(nil)
 			buildpacksBucket.CopyVersionReturns(nil)
 			packagesBucket.CopyVersionReturns(nil)
 
 			dropletsBucket.IsVersionedReturns(false, nil)
-			dropletsBucket.NameReturns("my_droplets_bucket")
 		})
 
 		It("returns an error", func() {
@@ -247,12 +333,18 @@ var _ = Describe("Restorer", func() {
 				},
 			}, nil)
 
+			dropletsBucket.NameReturns("my_droplets_bucket")
+			dropletsBucket.RegionReturns("my_droplets_region")
+			buildpacksBucket.NameReturns("my_buildpacks_bucket")
+			buildpacksBucket.RegionReturns("my_buildpacks_region")
+			packagesBucket.NameReturns("my_packages_bucket")
+			packagesBucket.RegionReturns("my_packages_region")
+
 			dropletsBucket.CopyVersionReturns(nil)
 			buildpacksBucket.CopyVersionReturns(nil)
 			packagesBucket.CopyVersionReturns(nil)
 
 			dropletsBucket.IsVersionedReturns(false, fmt.Errorf("ooops"))
-			dropletsBucket.NameReturns("my_droplets_bucket")
 		})
 
 		It("returns an error", func() {
@@ -279,6 +371,11 @@ var _ = Describe("Restorer", func() {
 					},
 				},
 			}, nil)
+
+			dropletsBucket.NameReturns("my_droplets_bucket")
+			dropletsBucket.RegionReturns("my_droplets_region")
+			buildpacksBucket.NameReturns("my_buildpacks_bucket")
+			buildpacksBucket.RegionReturns("my_buildpacks_region")
 
 			restorer = versioned.NewRestorer(map[string]versioned.Bucket{
 				"droplets":   dropletsBucket,


### PR DESCRIPTION
During unversioned restore, BuildRestoreBucketPairs now rejects any artifact whose bucket_name or bucket_region for a given bucket ID differs from the corresponding config.Backup.Name / config.Backup.Region values, and constructs the backup source bucket from the trusted config rather than the artifact JSON.

During versioned restore, Restorer.Run now rejects any artifact whose BucketName or RegionName for a given bucket does not match the configured destination bucket's Name() / Region(), and passes those same config-derived values as the CopyVersion source coordinates.

Both checks fail closed with a descriptive error before any S3 API call is made. Behaviour is unchanged for well-formed artifacts, where the config and artifact values are always identical.