### PR TITLE
ci: Pin to older jammy cf-deployment version

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -319,7 +319,7 @@ resources:
           vm_type: n2d-standard-8
           root_disk_gb: 32
           disk_pool_gb: 200
-          cfd_version: ""
+          cfd_version: "v52.0.0"
           cfd_additional_opsfiles_b64: "LS0tCi0gdHlwZTogcmVwbGFjZQogIHBhdGg6IC9hZGRvbnMvbmFtZT1ib3NoLWRucy1hbGlhc2VzL2pvYnMvbmFtZT1ib3NoLWRucy1hbGlhc2VzL3Byb3BlcnRpZXMvYWxpYXNlcy8tCiAgdmFsdWU6CiAgICBkb21haW46IF8uKChzeXN0ZW1fZG9tYWluKSkKICAgIHRhcmdldHM6CiAgICAgIC0gZGVwbG95bWVudDogY2YKICAgICAgICBkb21haW46IGJvc2gKICAgICAgICBpbnN0YW5jZV9ncm91cDogcm91dGVyCiAgICAgICAgbmV0d29yazogZGVmYXVsdAogICAgICAgIHF1ZXJ5OiAiKiI="
           bosh_additional_opsfiles_b64: ""
 
@@ -340,7 +340,7 @@ resources:
           vm_type: n2d-standard-8
           root_disk_gb: 32
           disk_pool_gb: 200
-          cfd_version: ""
+          cfd_version: "v52.0.0"
           cfd_additional_opsfiles_b64: "LS0tCi0gdHlwZTogcmVwbGFjZQogIHBhdGg6IC9hZGRvbnMvbmFtZT1ib3NoLWRucy1hbGlhc2VzL2pvYnMvbmFtZT1ib3NoLWRucy1hbGlhc2VzL3Byb3BlcnRpZXMvYWxpYXNlcy8tCiAgdmFsdWU6CiAgICBkb21haW46IF8uKChzeXN0ZW1fZG9tYWluKSkKICAgIHRhcmdldHM6CiAgICAgIC0gZGVwbG95bWVudDogY2YKICAgICAgICBkb21haW46IGJvc2gKICAgICAgICBpbnN0YW5jZV9ncm91cDogcm91dGVyCiAgICAgICAgbmV0d29yazogZGVmYXVsdAogICAgICAgIHF1ZXJ5OiAiKiI="
           bosh_additional_opsfiles_b64: ""
 


### PR DESCRIPTION
The host VMs for our test cf-deployment environments are Jammy, and thus don't work with virtualized Noble VMs. Pinning back to a Jammy version of cf-d should unblock the pipelines.

This change is already flown to the pipeline.